### PR TITLE
2.23 legacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ build
 #Android
 *.apk
 fabric.properties
+
+# last commit file
+app/src/main/res/raw/lastcommit.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "sdk"]
+	path = sdk
+	url = https://github.com/EyeSeeTea/dhis2-android-sdk
+	branch = tracker-capture

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,15 @@
         <meta-data
             android:name="io.fabric.ApiKey"
             android:value="a5caa46009119f5e584e4964c30a922095b1075c" />
+        <provider
+            android:name="org.hisp.dhis.android.trackercapture.export.DBProvider"
+            android:authorities="org.hisp.dhis.android.trackercapture.export.ExportData"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/MainActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/MainActivity.java
@@ -29,6 +29,8 @@
 
 package org.hisp.dhis.android.trackercapture;
 
+import static org.hisp.dhis.client.sdk.utils.StringUtils.isEmpty;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -45,14 +47,11 @@ import org.hisp.dhis.android.sdk.network.Session;
 import org.hisp.dhis.android.sdk.persistence.Dhis2Application;
 import org.hisp.dhis.android.sdk.persistence.models.UserAccount;
 import org.hisp.dhis.android.sdk.persistence.preferences.ResourceType;
-import org.hisp.dhis.android.sdk.utils.UiUtils;
 import org.hisp.dhis.android.trackercapture.activities.HolderActivity;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.SelectProgramFragment;
 import org.hisp.dhis.client.sdk.ui.activities.AbsHomeActivity;
 import org.hisp.dhis.client.sdk.ui.fragments.InformationFragment;
 import org.hisp.dhis.client.sdk.ui.fragments.WrapperFragment;
-
-import static org.hisp.dhis.client.sdk.utils.StringUtils.isEmpty;
 
 public class MainActivity extends AbsHomeActivity {
     public final static String TAG = MainActivity.class.getSimpleName();
@@ -147,8 +146,6 @@ public class MainActivity extends AbsHomeActivity {
     }
 
     public void loadInitialData() {
-        String message = getString(org.hisp.dhis.android.sdk.R.string.finishing_up);
-        UiUtils.postProgressMessage(message);
         DhisService.loadInitialData(MainActivity.this);
     }
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
@@ -12,7 +12,7 @@ import android.widget.Toast;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.activities.OnBackPressedListener;
 import org.hisp.dhis.android.sdk.ui.fragments.eventdataentry.EventDataEntryFragment;
-import org.hisp.dhis.android.sdk.ui.fragments.settings.SettingsFragment;
+import org.hisp.dhis.android.trackercapture.fragments.settings.SettingsFragment;
 import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.fragments.enrollment.EnrollmentDataEntryFragment;
 import org.hisp.dhis.android.trackercapture.fragments.enrollmentdate.EnrollmentDateFragment;

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
@@ -12,16 +12,18 @@ import android.widget.Toast;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.activities.OnBackPressedListener;
 import org.hisp.dhis.android.sdk.ui.fragments.eventdataentry.EventDataEntryFragment;
-import org.hisp.dhis.android.trackercapture.fragments.settings.SettingsFragment;
 import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.fragments.enrollment.EnrollmentDataEntryFragment;
 import org.hisp.dhis.android.trackercapture.fragments.enrollmentdate.EnrollmentDateFragment;
 import org.hisp.dhis.android.trackercapture.fragments.programoverview.ProgramOverviewFragment;
+import org.hisp.dhis.android.trackercapture.fragments.programoverview
+        .registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
 import org.hisp.dhis.android.trackercapture.fragments.search.LocalSearchFragment;
 import org.hisp.dhis.android.trackercapture.fragments.search.LocalSearchResultFragment;
 import org.hisp.dhis.android.trackercapture.fragments.search.OnlineSearchFragment;
 import org.hisp.dhis.android.trackercapture.fragments.search.OnlineSearchResultFragment;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.SelectProgramFragment;
+import org.hisp.dhis.android.trackercapture.fragments.settings.SettingsFragment;
 import org.hisp.dhis.android.trackercapture.fragments.trackedentityinstanceprofile.TrackedEntityInstanceProfileFragment;
 import org.hisp.dhis.android.trackercapture.fragments.upcomingevents.UpcomingEventsFragment;
 import org.hisp.dhis.client.sdk.ui.activities.AbsHomeActivity;
@@ -46,7 +48,7 @@ public class HolderActivity extends AbsHomeActivity {
     public static final String ARG_TYPE_ONLINESEARCHRESULTFRAGMENT = "arg:OnlineSearchResultFragment";
     private static final String ARG_TYPE_UPCOMINGEVENTSFRAGMENT = "arg:UpcomingEventsFragment";
     OnBackPressedListener onBackPressedListener;
-
+    public static RegisterRelationshipDialogFragment.CallBack mCallBack;
 
     @Override
     public void onBackPressed() {
@@ -275,16 +277,20 @@ public class HolderActivity extends AbsHomeActivity {
         activity.startActivity(intent);
     }
 
-    public static void navigateToOnlineSearchFragment(Activity activity, String programId, String orgUnitId) {
+    public static void navigateToOnlineSearchFragment(Activity activity, String programId,
+            String orgUnitId, boolean backNavigation,
+            RegisterRelationshipDialogFragment.CallBack callBack) {
+        mCallBack = callBack;
         Intent intent = new Intent(activity, HolderActivity.class);
         intent.putExtra(OnlineSearchFragment.EXTRA_PROGRAM, programId);
         intent.putExtra(OnlineSearchFragment.EXTRA_ORGUNIT, orgUnitId);
+        intent.putExtra(OnlineSearchFragment.EXTRA_NAVIGATION, backNavigation);
         intent.putExtra(ARG_TYPE, ARG_TYPE_ONLINESEARCHFRAGMENT);
         intent.setFlags(intent.getFlags() | Intent.FLAG_ACTIVITY_NO_HISTORY); // we don't want to keep it to backstack
         activity.startActivity(intent);
     }
 
-    public static void navigateToOnlineSearchResultFragment(Activity activity, List<TrackedEntityInstance> trackedEntityInstances, String orgUnit, String program) {
+    public static void navigateToOnlineSearchResultFragment(Activity activity, List<TrackedEntityInstance> trackedEntityInstances, String orgUnit, String program, boolean backNavigation) {
         try {
             Intent intent = new Intent(activity, HolderActivity.class);
 
@@ -299,6 +305,7 @@ public class HolderActivity extends AbsHomeActivity {
             intent.putExtra(OnlineSearchResultFragment.EXTRA_PROGRAM, program);
             intent.putExtra(OnlineSearchResultFragment.EXTRA_TRACKEDENTITYINSTANCESSELECTED, parameterSerializible1);
             intent.putExtra(OnlineSearchResultFragment.EXTRA_TRACKEDENTITYINSTANCESLIST, parameterSerializible2);
+            intent.putExtra(OnlineSearchResultFragment.EXTRA_NAVIGATION, backNavigation);
             intent.putExtra(ARG_TYPE, ARG_TYPE_ONLINESEARCHRESULTFRAGMENT);
             intent.setFlags(intent.getFlags() | Intent.FLAG_ACTIVITY_NO_HISTORY); // we don't want to keep it to backstack
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/export/DBProvider.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/export/DBProvider.java
@@ -1,0 +1,9 @@
+package org.hisp.dhis.android.trackercapture.export;
+
+import android.support.v4.content.FileProvider;
+
+public class DBProvider extends FileProvider {
+    public DBProvider(){
+        super();
+    }
+}

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/export/ExportData.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/export/ExportData.java
@@ -1,0 +1,288 @@
+package org.hisp.dhis.android.trackercapture.export;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.support.v4.app.ShareCompat;
+import android.support.v4.content.FileProvider;
+import android.util.Log;
+
+import org.hisp.dhis.android.sdk.R;
+import org.hisp.dhis.android.sdk.persistence.Dhis2Database;
+import org.hisp.dhis.client.sdk.ui.BuildConfig;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.channels.FileChannel;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class ExportData {
+
+    private final String TAG = ".ExportData";
+
+    /**
+     * Temporal folder that contains all the files to send
+     */
+    private final String EXPORT_DATA_FOLDER = "exportdata/";
+    /**
+     * Temporal file to be attached
+     */
+    private final String EXPORT_DATA_FILE = "compressedData.zip";
+    /**
+     * Temporal file that contains phonemetadata and app version info
+     */
+    private final String EXTRA_INFO = "extrainfo.txt";
+    /**
+     * Databases folder
+     */
+    private final String DATABASE_FOLDER = "databases/";
+    /**
+     * Shared preferences folder
+     */
+    private final String SHAREDPREFERENCES_FOLDER = "shared_prefs/";
+
+    private Context mContext;
+
+    public static String getCommitHash(Context context) {
+        String stringCommit;
+        //Check if lastcommit.txt file exist, and if not exist show as unavailable.
+        int layoutId = context.getResources().getIdentifier("lastcommit", "raw",
+                context.getPackageName());
+        if (layoutId == 0) {
+            stringCommit = "";
+        } else {
+            InputStream commit = context.getResources().openRawResource(layoutId);
+            stringCommit = convertFromInputStreamToString(commit).toString();
+        }
+        return stringCommit;
+    }
+
+    public static StringBuilder convertFromInputStreamToString(InputStream inputStream) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        try {
+            BufferedReader r = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+            String line;
+            while ((line = r.readLine()) != null) {
+                stringBuilder.append(line + "\n");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return stringBuilder;
+    }
+
+    /**
+     * This method create the dump and returns the intent
+     */
+    public Intent dumpAndSendToAIntent(Activity activity) throws IOException {
+        mContext = activity.getBaseContext();
+        removeDumpIfExist(activity);
+        File tempFolder = new File(getCacheDir() + "/" + EXPORT_DATA_FOLDER);
+        tempFolder.mkdir();
+        //copy database
+        dumpDatabase(Dhis2Database.NAME + ".db", tempFolder);
+        //Copy the sharedPreferences
+        dumpSharedPreferences(tempFolder);
+
+        //copy phonemetadata and gradle version
+        File customInformation = new File(tempFolder + "/" + EXTRA_INFO);
+        dumpMetadata(customInformation, activity);
+
+        //compress and send
+        File compressedFile = compressFolder(tempFolder);
+        if (compressedFile == null) {
+            return null;
+        }
+        return createEmailIntent(activity, compressedFile);
+    }
+
+    /**
+     * This method create the dump the metadata in a temporally file
+     */
+    private void dumpMetadata(File customInformation, Activity activity)
+            throws IOException {
+        customInformation.createNewFile();
+        FileWriter fw = new FileWriter(customInformation.getAbsoluteFile(), true);
+        BufferedWriter bw = new BufferedWriter(fw);
+        bw.write("Flavour: " + BuildConfig.FLAVOR + "\n");
+        bw.write("Version code: " + BuildConfig.VERSION_CODE + "\n");
+        bw.write("Version name: " + BuildConfig.VERSION_NAME + "\n");
+        bw.write("Application Id: " + BuildConfig.APPLICATION_ID + "\n");
+        bw.write("Build type: " + BuildConfig.BUILD_TYPE + "\n");
+        bw.write("Hash: " + getCommitHash(activity));
+
+        bw.close();
+        fw.close();
+    }
+
+    /**
+     * This method checks if the tempfolder contains files and zip it.
+     */
+    private File compressFolder(File tempFolder) throws IOException {
+        if (tempFolder.listFiles() == null) {
+            Log.d(TAG, "Error, nothing to convert");
+            return null;
+        }
+        zipFolder(tempFolder.getAbsolutePath(), getCacheDir() + "/" + EXPORT_DATA_FILE);
+        File file = new File(getCacheDir() + "/" + EXPORT_DATA_FILE);
+        return file;
+    }
+
+
+    /**
+     * This method compress all the files in the temporal folder to be sent
+     */
+    private void zipFolder(String inputFolderPath, String outputFilePath) throws IOException {
+        try {
+            FileOutputStream fos = new FileOutputStream(outputFilePath);
+            ZipOutputStream zos = new ZipOutputStream(fos);
+            File srcFile = new File(inputFolderPath);
+            File[] files = srcFile.listFiles();
+            Log.d("", "Zip directory: " + srcFile.getName());
+            for (int i = 0; i < files.length; i++) {
+                Log.d("", "Adding file: " + files[i].getName());
+                byte[] buffer = new byte[1024];
+                FileInputStream fis = new FileInputStream(files[i]);
+                zos.putNextEntry(new ZipEntry(files[i].getName()));
+                int length;
+                while ((length = fis.read(buffer)) > 0) {
+                    zos.write(buffer, 0, length);
+                }
+                zos.closeEntry();
+                fis.close();
+            }
+            zos.close();
+        } catch (IOException e) {
+            throw new IOException(e);
+        }
+    }
+
+
+    /**
+     * This method dump a database
+     */
+    private void dumpDatabase(String dbName, File tempFolder) throws IOException {
+        File backupDB = null;
+        if (tempFolder.canWrite()) {
+            File currentDB = new File(getDatabasesFolder(), dbName);
+            backupDB = new File(tempFolder, dbName);
+            copyFile(currentDB, backupDB);
+        }
+    }
+
+    /**
+     * This method dump the sharedPreferences
+     */
+    private void dumpSharedPreferences(File tempFolder) throws IOException {
+        File files[] = getSharedPreferencesFolder().listFiles();
+        Log.d("Files", "Size: " + files.length);
+        for (int i = 0; i < files.length; i++) {
+            Log.d("Files", "FileName:" + files[i].getName());
+            copyFile(files[i], new File(tempFolder, files[i].getName()));
+        }
+    }
+
+    /**
+     * This method copy a file in other file
+     */
+    private void copyFile(File current, File backup) throws IOException {
+        if (current.exists()) {
+            FileChannel src = new FileInputStream(current)
+                    .getChannel();
+            FileChannel dst = new FileOutputStream(backup)
+                    .getChannel();
+            dst.transferFrom(src, 0, src.size());
+            src.close();
+            dst.close();
+        }
+    }
+
+    /**
+     * This method returns the app cache dir
+     */
+    private File getCacheDir() {
+        return mContext.getCacheDir();
+
+    }
+
+    /**
+     * This method returns the app path
+     */
+    private String getAppPath() {
+        return "/data/data/" + mContext.getPackageName() + "/";
+
+    }
+
+    /**
+     * This method returns the sharedPreferences app folder
+     */
+    private File getSharedPreferencesFolder() {
+        String sharedPreferencesPath = getAppPath() + SHAREDPREFERENCES_FOLDER;
+        File file = new File(sharedPreferencesPath);
+        return file;
+    }
+
+    /**
+     * This method returns the databases app folder
+     */
+    private File getDatabasesFolder() {
+        String databasesPath = getAppPath() + DATABASE_FOLDER;
+        File file = new File(databasesPath);
+        return file;
+    }
+
+    /**
+     * This method create the email intent
+     */
+    private Intent createEmailIntent(Activity activity, File data) {
+        Log.d(TAG, data.toURI() + "");
+        data.setReadable(true, false);
+        final Uri uri = FileProvider.getUriForFile(activity,
+                "org.hisp.dhis.android.trackercapture.export.ExportData", data);
+
+        final Intent chooser = ShareCompat.IntentBuilder.from(activity)
+                .setType("application/zip")
+                .setSubject(mContext.getString(
+                        R.string.app_name)
+                        + " db " + new SimpleDateFormat("yyyy/MM/dd HH:mm:ss").format(
+                        Calendar.getInstance().getTime()))
+                .setStream(uri)
+                .setChooserTitle(
+                        activity.getResources().getString(R.string.export_data_name))
+                .createChooserIntent()
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+        return chooser;
+    }
+
+    /**
+     * This method remove the dump.
+     */
+    public void removeDumpIfExist(Activity activity) {
+        File file = new File(activity.getCacheDir() + "/" + EXPORT_DATA_FILE);
+        file.delete();
+
+        File tempFolder = new File(activity.getCacheDir() + "/" + EXPORT_DATA_FOLDER);
+        File[] files = tempFolder.listFiles();
+        if (files == null) {
+            return;
+        }
+        for (int i = 0; i < files.length; i++) {
+            files[i].delete();
+        }
+        tempFolder.delete();
+    }
+}

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragmentQuery.java
@@ -157,7 +157,7 @@ class EnrollmentDataEntryFragmentQuery implements Query<EnrollmentDataEntryFragm
                     getTrackedEntityDataValue(programTrackedEntityAttributes.get(i).
                             getTrackedEntityAttribute().getUid(), trackedEntityAttributeValues),
                     programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getValueType(),
-                    editable, shouldNeverBeEdited);
+                    editable, shouldNeverBeEdited, mProgram.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         for (TrackedEntityAttributeValue trackedEntityAttributeValue : trackedEntityAttributeValues) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -97,10 +97,12 @@ import org.hisp.dhis.android.sdk.utils.comparators.EnrollmentDateComparator;
 import org.hisp.dhis.android.sdk.utils.services.ProgramRuleService;
 import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.activities.HolderActivity;
-import org.hisp.dhis.android.trackercapture.fragments.programoverview.registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
+import org.hisp.dhis.android.trackercapture.fragments.programoverview
+        .registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.EnrollmentDateSetterHelper;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.IEnroller;
-import org.hisp.dhis.android.trackercapture.fragments.selectprogram.dialogs.ItemStatusDialogFragment;
+import org.hisp.dhis.android.trackercapture.fragments.selectprogram.dialogs
+        .ItemStatusDialogFragment;
 import org.hisp.dhis.android.trackercapture.ui.adapters.ProgramAdapter;
 import org.hisp.dhis.android.trackercapture.ui.adapters.ProgramStageAdapter;
 import org.hisp.dhis.android.trackercapture.ui.rows.programoverview.OnProgramStageEventClick;
@@ -637,28 +639,44 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                     if (relative != null && relative.getAttributes() != null) {
                         List<Enrollment> enrollments = TrackerController.getEnrollments(relative);
                         List<TrackedEntityAttribute> attributesToShow = new ArrayList<>();
-                        if (enrollments != null && !enrollments.isEmpty()) {
-                            Program program = null;
-                            for (Enrollment e : enrollments) {
-                                if (e != null && e.getProgram() != null && e.getProgram().getProgramTrackedEntityAttributes() != null) {
-                                    program = e.getProgram();
-                                    break;
+                        List<TrackedEntityAttributeValue> attributes = TrackerController.getVisibleTrackedEntityAttributeValues(relative.getLocalId());
+                        for (int i = 0; i < attributes.size() && i < 2; i++) {
+                            relativeString += attributes.get(i).getValue() + " ";
+                        }
+                        if(attributes.size() == 0) {
+                            if (enrollments != null && !enrollments.isEmpty()) {
+                                Program program = null;
+                                for (Enrollment e : enrollments) {
+                                    if (e != null && e.getProgram() != null
+                                            && e.getProgram().getProgramTrackedEntityAttributes()
+                                            != null) {
+                                        program = e.getProgram();
+                                        break;
+                                    }
                                 }
-                            }
-                            List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes = program.getProgramTrackedEntityAttributes();
-                            for (int i = 0; i < programTrackedEntityAttributes.size() && i < 2; i++) {
-                                attributesToShow.add(programTrackedEntityAttributes.get(i).getTrackedEntityAttribute());
-                            }
-                            for (int i = 0; i < attributesToShow.size() && i < 2; i++) {
-                                TrackedEntityAttributeValue av = TrackerController.getTrackedEntityAttributeValue(attributesToShow.get(i).getUid(), relative.getLocalId());
-                                if (av != null && av.getValue() != null) {
-                                    relativeString += av.getValue() + " ";
+                                List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes =
+                                        program.getProgramTrackedEntityAttributes();
+                                for (int i = 0; i < programTrackedEntityAttributes.size() && i < 2;
+                                        i++) {
+                                    attributesToShow.add(programTrackedEntityAttributes.get(
+                                            i).getTrackedEntityAttribute());
                                 }
-                            }
-                        } else {
-                            for (int i = 0; i < relative.getAttributes().size() && i < 2; i++) {
-                                if (relative.getAttributes().get(i) != null && relative.getAttributes().get(i).getValue() != null) {
-                                    relativeString += relative.getAttributes().get(i).getValue() + " ";
+                                for (int i = 0; i < attributesToShow.size() && i < 2; i++) {
+                                    TrackedEntityAttributeValue av =
+                                            TrackerController.getTrackedEntityAttributeValue(
+                                                    attributesToShow.get(i).getUid(),
+                                                    relative.getLocalId());
+                                    if (av != null && av.getValue() != null) {
+                                        relativeString += av.getValue() + " ";
+                                    }
+                                }
+                            } else {
+                                for (int i = 0; i < relative.getAttributes().size() && i < 2; i++) {
+                                    if (relative.getAttributes().get(i) != null
+                                            && relative.getAttributes().get(i).getValue() != null) {
+                                        relativeString += relative.getAttributes().get(i).getValue()
+                                                + " ";
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -508,6 +508,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 enrollmentServerStatus.setImageResource(R.drawable.ic_from_server);
             }
 
+            refreshRelationshipButton.setEnabled(mForm.getEnrollment().isFromServer());
+
             if (mForm.getEnrollment().getStatus().equals(Enrollment.CANCELLED)) {
                 setTerminated();
             }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -97,10 +97,12 @@ import org.hisp.dhis.android.sdk.utils.comparators.EnrollmentDateComparator;
 import org.hisp.dhis.android.sdk.utils.services.ProgramRuleService;
 import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.activities.HolderActivity;
-import org.hisp.dhis.android.trackercapture.fragments.programoverview.registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
+import org.hisp.dhis.android.trackercapture.fragments.programoverview
+        .registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.EnrollmentDateSetterHelper;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.IEnroller;
-import org.hisp.dhis.android.trackercapture.fragments.selectprogram.dialogs.ItemStatusDialogFragment;
+import org.hisp.dhis.android.trackercapture.fragments.selectprogram.dialogs
+        .ItemStatusDialogFragment;
 import org.hisp.dhis.android.trackercapture.ui.adapters.ProgramAdapter;
 import org.hisp.dhis.android.trackercapture.ui.adapters.ProgramStageAdapter;
 import org.hisp.dhis.android.trackercapture.ui.rows.programoverview.OnProgramStageEventClick;
@@ -179,7 +181,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
         setProgramRuleFragmentHelper(new ProgramOverviewRuleHelper(this));
     }
 
-    public static ProgramOverviewFragment newInstance(String orgUnitId, String programId, long trackedEntityInstanceId) {
+    public static ProgramOverviewFragment newInstance(String orgUnitId, String programId,
+            long trackedEntityInstanceId) {
         ProgramOverviewFragment fragment = new ProgramOverviewFragment();
         Bundle args = new Bundle();
         args.putString(ORG_UNIT_ID, orgUnitId);
@@ -234,7 +237,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+            Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_programoverview, container, false);
     }
 
@@ -251,11 +255,14 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 R.layout.fragment_programoverview_header, listView, false
         );
 
-        mSwipeRefreshLayout = (SwipeRefreshLayout) view.findViewById(org.hisp.dhis.android.sdk.R.id.swipe_to_refresh_layout);
-        mSwipeRefreshLayout.setColorSchemeResources(org.hisp.dhis.android.sdk.R.color.Green, org.hisp.dhis.android.sdk.R.color.Blue, org.hisp.dhis.android.sdk.R.color.orange);
+        mSwipeRefreshLayout = (SwipeRefreshLayout) view.findViewById(
+                org.hisp.dhis.android.sdk.R.id.swipe_to_refresh_layout);
+        mSwipeRefreshLayout.setColorSchemeResources(org.hisp.dhis.android.sdk.R.color.Green,
+                org.hisp.dhis.android.sdk.R.color.Blue, org.hisp.dhis.android.sdk.R.color.orange);
         mSwipeRefreshLayout.setOnRefreshListener(this);
 
-        relationshipsLinearLayout = (LinearLayout) header.findViewById(R.id.relationships_linearlayout);
+        relationshipsLinearLayout = (LinearLayout) header.findViewById(
+                R.id.relationships_linearlayout);
 
         refreshRelationshipButton = (Button) header.findViewById(R.id.pullrelationshipbutton);
         refreshRelationshipButton.setOnClickListener(this);
@@ -312,11 +319,14 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
         }
         if (mState == null) {
             mState = new ProgramOverviewFragmentState();
-            OrganisationUnit ou = MetaDataController.getOrganisationUnit(fragmentArguments.getString(ORG_UNIT_ID));
-            Program program = MetaDataController.getProgram(fragmentArguments.getString(PROGRAM_ID));
+            OrganisationUnit ou = MetaDataController.getOrganisationUnit(
+                    fragmentArguments.getString(ORG_UNIT_ID));
+            Program program = MetaDataController.getProgram(
+                    fragmentArguments.getString(PROGRAM_ID));
             mState.setOrgUnit(ou.getId(), ou.getLabel());
             mState.setProgram(program.getUid(), program.getName());
-            mState.setTrackedEntityInstance(fragmentArguments.getLong(TRACKEDENTITYINSTANCE_ID, -1));
+            mState.setTrackedEntityInstance(
+                    fragmentArguments.getLong(TRACKEDENTITYINSTANCE_ID, -1));
         }
         attachSpinner();
         mSpinnerAdapter.swapData(MetaDataController.getProgramsForOrganisationUnit
@@ -394,8 +404,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
         int index = -1;
         for (int i = 0; i < mSpinnerAdapter.getCount(); i++) {
             Program program = (Program) mSpinnerAdapter.getItem(i);
-            if (program.getName().equals(programName))
+            if (program.getName().equals(programName)) {
                 index = i;
+            }
         }
         return index;
     }
@@ -414,7 +425,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
 
             mSpinnerAdapter = new ProgramAdapter(inflater);
 
-            mSpinner = (Spinner) mSpinnerContainer.findViewById(org.hisp.dhis.android.sdk.R.id.toolbar_spinner);
+            mSpinner = (Spinner) mSpinnerContainer.findViewById(
+                    org.hisp.dhis.android.sdk.R.id.toolbar_spinner);
             mSpinner.setAdapter(mSpinnerAdapter);
             mSpinner.post(new Runnable() {
                 public void run() {
@@ -471,7 +483,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     @Override
-    public void onLoadFinished(Loader<ProgramOverviewFragmentForm> loader, ProgramOverviewFragmentForm data) {
+    public void onLoadFinished(Loader<ProgramOverviewFragmentForm> loader,
+            ProgramOverviewFragmentForm data) {
         if (LOADER_ID == loader.getId()) {
             mForm = data;
             mProgressBar.setVisibility(View.GONE);
@@ -485,7 +498,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
             } else {
                 enrollmentLayout.setVisibility(View.VISIBLE);
                 missingEnrollmentLayout.setVisibility(View.GONE);
-                profileCardView.setClickable(true); //is set to false when TEI doesn't have an applicable enrollment. todo why?
+                profileCardView.setClickable(
+                        true); //is set to false when TEI doesn't have an applicable enrollment.
+                // todo why?
                 profileButton.setClickable(true);
             }
             enrollmentDateLabel.setText(data.getDateOfEnrollmentLabel());
@@ -498,7 +513,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 incidentDateLabel.setText(data.getIncidentDateLabel());
                 incidentDateValue.setText(data.getIncidentDateValue());
             }
-            FailedItem failedItem = TrackerController.getFailedItem(FailedItem.ENROLLMENT, mForm.getEnrollment().getLocalId());
+            FailedItem failedItem = TrackerController.getFailedItem(FailedItem.ENROLLMENT,
+                    mForm.getEnrollment().getLocalId());
 
             if (failedItem != null && failedItem.getHttpStatusCode() >= 0) {
                 enrollmentServerStatus.setImageResource(R.drawable.ic_event_error);
@@ -540,7 +556,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                     if (stageRow.getProgramStage().getRepeatable()) {
                         stageRow.setButtonListener(this);
                     } else {
-                        if (stageRow.getEventRows().size() < 1) { // if stage is not autogen and not repeatable, allow user to create exactly one event
+                        if (stageRow.getEventRows().size()
+                                < 1) { // if stage is not autogen and not repeatable, allow user
+                            // to create exactly one event
                             stageRow.setButtonListener(this);
                         }
                         if (stageRow.getProgramStage().getAllowGenerateNextVisit()) {
@@ -551,11 +569,13 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 } else if (row instanceof ProgramStageEventRow) {
                     final ProgramStageEventRow eventRow = (ProgramStageEventRow) row;
 
-                    FailedItem failedItem1 = TrackerController.getFailedItem(FailedItem.EVENT, eventRow.getEvent().getLocalId());
+                    FailedItem failedItem1 = TrackerController.getFailedItem(FailedItem.EVENT,
+                            eventRow.getEvent().getLocalId());
 
                     if (failedItem1 != null && failedItem1.getHttpStatusCode() >= 0) {
                         eventRow.setHasFailed(true);
-                        eventRow.setMessage(failedEvents.get(eventRow.getEvent().getLocalId()).getErrorMessage());
+                        eventRow.setMessage(failedEvents.get(
+                                eventRow.getEvent().getLocalId()).getErrorMessage());
                     } else if (eventRow.getEvent().isFromServer()) {
                         eventRow.setSynchronized(true);
                         eventRow.setMessage(getString(R.string.status_sent_description));
@@ -565,16 +585,22 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                     }
                 }
             }
-            setRelationships(getLayoutInflater(getArguments().getBundle(EXTRA_SAVED_INSTANCE_STATE)));
+            setRelationships(
+                    getLayoutInflater(getArguments().getBundle(EXTRA_SAVED_INSTANCE_STATE)));
 
-            LinearLayout programIndicatorLayout = (LinearLayout) programIndicatorCardView.findViewById(R.id.programindicatorlayout);
+            LinearLayout programIndicatorLayout =
+                    (LinearLayout) programIndicatorCardView.findViewById(
+                            R.id.programindicatorlayout);
             programIndicatorLayout.removeAllViews();
-            FlowLayout keyValueLayout = (FlowLayout) programIndicatorCardView.findViewById(R.id.keyvaluelayout);
+            FlowLayout keyValueLayout = (FlowLayout) programIndicatorCardView.findViewById(
+                    R.id.keyvaluelayout);
             keyValueLayout.removeAllViews();
-            LinearLayout displayTextLayout = (LinearLayout) programIndicatorCardView.findViewById(R.id.textlayout);
+            LinearLayout displayTextLayout = (LinearLayout) programIndicatorCardView.findViewById(
+                    R.id.textlayout);
             displayTextLayout.removeAllViews();
             for (IndicatorRow indicatorRow : mForm.getProgramIndicatorRows().values()) {
-                View view = indicatorRow.getView(getChildFragmentManager(), getLayoutInflater(getArguments()), null, programIndicatorLayout);
+                View view = indicatorRow.getView(getChildFragmentManager(),
+                        getLayoutInflater(getArguments()), null, programIndicatorLayout);
                 programIndicatorLayout.addView(view);
             }
 
@@ -589,16 +615,21 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
      */
     public void setRelationships(LayoutInflater inflater) {
         relationshipsLinearLayout.removeAllViews();
-        if (mForm.getTrackedEntityInstance() != null && mForm.getTrackedEntityInstance().getRelationships() != null) {
-            ListIterator<Relationship> it = mForm.getTrackedEntityInstance().getRelationships().listIterator();
+        if (mForm.getTrackedEntityInstance() != null
+                && mForm.getTrackedEntityInstance().getRelationships() != null) {
+            ListIterator<Relationship> it =
+                    mForm.getTrackedEntityInstance().getRelationships().listIterator();
             while (it.hasNext()) {
                 final Relationship relationship = it.next();
                 if (relationship == null) {
                     continue;
                 }
-                LinearLayout ll = (LinearLayout) inflater.inflate(R.layout.listview_row_relationship, null);
-                FontTextView currentTeiRelationshipLabel = (FontTextView) ll.findViewById(R.id.current_tei_relationship_label);
-                FontTextView relativeLabel = (FontTextView) ll.findViewById(R.id.relative_relationship_label);
+                LinearLayout ll = (LinearLayout) inflater.inflate(
+                        R.layout.listview_row_relationship, null);
+                FontTextView currentTeiRelationshipLabel = (FontTextView) ll.findViewById(
+                        R.id.current_tei_relationship_label);
+                FontTextView relativeLabel = (FontTextView) ll.findViewById(
+                        R.id.relative_relationship_label);
                 Button deleteButton = (Button) ll.findViewById(R.id.delete_relationship);
                 deleteButton.setOnClickListener(new View.OnClickListener() {
                     @Override
@@ -607,23 +638,29 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                                 mForm.getTrackedEntityInstance(), getActivity());
                     }
                 });
-                RelationshipType relationshipType = MetaDataController.getRelationshipType(relationship.getRelationship());
+                RelationshipType relationshipType = MetaDataController.getRelationshipType(
+                        relationship.getRelationship());
 
                 if (relationshipType != null) {
 
                     /* establishing if the relative is A or B in Relationship Type */
                     final TrackedEntityInstance relative;
                     if (mForm.getTrackedEntityInstance().getTrackedEntityInstance() != null &&
-                            mForm.getTrackedEntityInstance().getTrackedEntityInstance().equals(relationship.getTrackedEntityInstanceA())) {
+                            mForm.getTrackedEntityInstance().getTrackedEntityInstance().equals(
+                                    relationship.getTrackedEntityInstanceA())) {
 
                         currentTeiRelationshipLabel.setText(relationshipType.getaIsToB());
-                        relative = TrackerController.getTrackedEntityInstance(relationship.getTrackedEntityInstanceB());
+                        relative = TrackerController.getTrackedEntityInstance(
+                                relationship.getTrackedEntityInstanceB());
 
-                    } else if (mForm.getTrackedEntityInstance().getTrackedEntityInstance() != null &&
-                            mForm.getTrackedEntityInstance().getTrackedEntityInstance().equals(relationship.getTrackedEntityInstanceB())) {
+                    } else if (mForm.getTrackedEntityInstance().getTrackedEntityInstance() != null
+                            &&
+                            mForm.getTrackedEntityInstance().getTrackedEntityInstance().equals(
+                                    relationship.getTrackedEntityInstanceB())) {
 
                         currentTeiRelationshipLabel.setText(relationshipType.getbIsToA());
-                        relative = TrackerController.getTrackedEntityInstance(relationship.getTrackedEntityInstanceA());
+                        relative = TrackerController.getTrackedEntityInstance(
+                                relationship.getTrackedEntityInstanceA());
                     } else {
                         continue;
                     }
@@ -638,7 +675,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                             if (relative != null) {
                                 ProgramOverviewFragment fragment = ProgramOverviewFragment.
                                         newInstance(getArguments().getString(ORG_UNIT_ID),
-                                                getArguments().getString(PROGRAM_ID), relative.getLocalId());
+                                                getArguments().getString(PROGRAM_ID),
+                                                relative.getLocalId());
 //                                mNavigationHandler.switchFragment(fragment, CLASS_TAG, true);
                             }
                         }
@@ -646,7 +684,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                     relationshipsLinearLayout.addView(ll);
                     if (it.hasNext()) {
                         View view = new View(getActivity());
-                        view.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 1));
+                        view.setLayoutParams(
+                                new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                        1));
                         view.setBackgroundColor(getResources().getColor(R.color.light_grey));
                         relationshipsLinearLayout.addView(view);
                     }
@@ -662,11 +702,12 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
         if (relative != null && relative.getAttributes() != null) {
             List<Enrollment> enrollments = TrackerController.getEnrollments(relative);
             List<TrackedEntityAttribute> attributesToShow = new ArrayList<>();
-            List<TrackedEntityAttributeValue> attributes = TrackerController.getVisibleTrackedEntityAttributeValues(relative.getLocalId());
+            List<TrackedEntityAttributeValue> attributes =
+                    TrackerController.getVisibleTrackedEntityAttributeValues(relative.getLocalId());
             for (int i = 0; i < attributes.size() && i < 2; i++) {
                 relativeString += attributes.get(i).getValue() + " ";
             }
-            if(attributes.size() == 0) {
+            if (attributes.size() == 0) {
                 if (enrollments != null && !enrollments.isEmpty()) {
                     Program program = null;
                     for (Enrollment e : enrollments) {
@@ -711,8 +752,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     public static void showConfirmDeleteRelationshipDialog(final Relationship relationship,
-                                                           final TrackedEntityInstance trackedEntityInstance,
-                                                           Activity activity) {
+            final TrackedEntityInstance trackedEntityInstance,
+            Activity activity) {
         if (activity == null) return;
         UiUtils.showConfirmDialog(activity, activity.getString(R.string.confirm),
                 activity.getString(R.string.confirm_delete_relationship),
@@ -731,8 +772,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     @Subscribe
     public void onItemClick(OnProgramStageEventClick eventClick) {
         if (eventClick.isHasPressedFailedButton()) {
-            if (eventClick.getEvent() != null)
+            if (eventClick.getEvent() != null) {
                 showStatusDialog(eventClick.getEvent());
+            }
         } else {
             showDataEntryFragment(eventClick.getEvent(), eventClick.getEvent().getProgramStageId());
         }
@@ -743,8 +785,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
         List<FailedItem> failedItems = TrackerController.getFailedItems();
         if (failedItems != null && failedItems.size() > 0) {
             for (FailedItem failedItem : failedItems) {
-                if (failedItem.getItemType().equals(FailedItem.EVENT))
+                if (failedItem.getItemType().equals(FailedItem.EVENT)) {
                     failedItemMap.put(failedItem.getItemId(), failedItem);
+                }
             }
         }
         return failedItemMap;
@@ -759,66 +802,45 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
             missingEnrollmentLayout.setVisibility(View.GONE);
         }
 
-        //update profile view
-        List<Enrollment> enrollmentsForTEI = TrackerController.getEnrollments(TrackerController.getTrackedEntityInstance(mState.getTrackedEntityInstanceId()));
-        for (Enrollment enrollment : enrollmentsForTEI) {
-            Program selectedProgram = (Program) mSpinner.getSelectedItem();
-
-            if (selectedProgram.getUid().equals(enrollment.getProgram().getUid())) {
-                profileCardView.setClickable(false); // Enrollment attributes is applicable.
-                profileButton.setClickable(false);
-                TrackedEntityInstance trackedEntityInstance = TrackerController.getTrackedEntityInstance(enrollment.getLocalTrackedEntityInstanceId());
-
-                int numberOfProgramTrackedEntityAttributes = selectedProgram.getProgramTrackedEntityAttributes().size();
-                int numberOfTrackedEntityAttributeValues = trackedEntityInstance.getAttributes().size();
-
-                if (numberOfProgramTrackedEntityAttributes > 0 && numberOfTrackedEntityAttributeValues > 0) {
-                    TrackedEntityAttribute attribute1 = selectedProgram.getProgramTrackedEntityAttributes().get(0).getTrackedEntityAttribute();
-                    attribute1Label.setText(attribute1.getName());
-                    TrackedEntityAttributeValue attribute1Val = TrackerController.getTrackedEntityAttributeValue(attribute1.getUid(), trackedEntityInstance.getLocalId());
-                    if (attribute1Val != null) {
-                        attribute1Value.setText(attribute1Val.getValue());
-                    } else {
-                        attribute1Value.setText("");
-                    }
-                } else {
-                    attribute1Label.setText("");
-                    attribute1Value.setText("");
+        TrackedEntityInstance trackedEntityInstance = TrackerController.getTrackedEntityInstance(
+                mForm.getTrackedEntityInstance().getTrackedEntityInstance());
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues =
+                TrackerController.getVisibleTrackedEntityAttributeValues(
+                        trackedEntityInstance.getLocalId());
+        {
+            //update profile view
+            if (trackedEntityAttributeValues != null) {
+                TrackedEntityAttribute attribute = MetaDataController.getTrackedEntityAttribute(
+                        trackedEntityAttributeValues.get(0).getTrackedEntityAttributeId());
+                if (attribute != null) {
+                    attribute1Label.setText(attribute.getName());
+                    attribute1Value.setText(trackedEntityAttributeValues.get(0).getValue());
                 }
-
-                if (numberOfProgramTrackedEntityAttributes > 1 && numberOfTrackedEntityAttributeValues > 1) {
-                    TrackedEntityAttribute attribute2 = selectedProgram.getProgramTrackedEntityAttributes().get(1).getTrackedEntityAttribute();
-                    TrackedEntityAttributeValue attribute2Val = TrackerController.getTrackedEntityAttributeValue(attribute2.getUid(), trackedEntityInstance.getLocalId());
-
-                    attribute2Label.setText(attribute2.getName());
-                    if (attribute2Val != null) {
-                        attribute2Value.setText(attribute2Val.getValue());
-                    } else {
-                        attribute2Value.setText("");
-                    }
-                } else {
-                    attribute2Label.setText("");
-                    attribute2Value.setText("");
+                attribute = MetaDataController.getTrackedEntityAttribute(
+                        trackedEntityAttributeValues.get(1).getTrackedEntityAttributeId());
+                if (attribute != null) {
+                    attribute2Label.setText(attribute.getName());
+                    attribute2Value.setText(trackedEntityAttributeValues.get(1).getValue());
                 }
+            }
 
-                break;
-            } else {
-                profileCardView.setClickable(false); // Enrollment attributes not applicable. Clickable(false) to prevent crash
-                profileButton.setClickable(false);
-                int numberOfProgramTrackedEntityAttributes = selectedProgram.getProgramTrackedEntityAttributes().size();
+            List<Enrollment> enrollmentsForTEI = TrackerController.getEnrollments(
+                    TrackerController.getTrackedEntityInstance(
+                            mState.getTrackedEntityInstanceId()));
+            for (Enrollment enrollment : enrollmentsForTEI) {
+                Program selectedProgram = (Program) mSpinner.getSelectedItem();
 
-                if (numberOfProgramTrackedEntityAttributes > 0)
-                    attribute1Label.setText(selectedProgram.getProgramTrackedEntityAttributes().get(0).getTrackedEntityAttribute().getName());
-                else
-                    attribute1Label.setText("");
+                if (selectedProgram.getUid().equals(enrollment.getProgram().getUid())) {
+                    profileCardView.setClickable(false); // Enrollment attributes is applicable.
+                    profileButton.setClickable(false);
+                    break;
+                } else {
+                    profileCardView.setClickable(
+                            false); // Enrollment attributes not applicable. Clickable(false) to
+                    // prevent crash
 
-                if (numberOfProgramTrackedEntityAttributes > 1)
-                    attribute2Label.setText(selectedProgram.getProgramTrackedEntityAttributes().get(1).getTrackedEntityAttribute().getName());
-                else
-                    attribute2Label.setText("");
-
-                attribute1Value.setText("");
-                attribute2Value.setText("");
+                    profileButton.setClickable(false);
+                }
             }
         }
     }
@@ -839,39 +861,50 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     private void createEnrollment() {
-        EnrollmentDateSetterHelper.createEnrollment(mForm.getTrackedEntityInstance(), this, getActivity(), mForm.getProgram().
-                        getDisplayIncidentDate(), mForm.getProgram().getSelectEnrollmentDatesInFuture(),
-                mForm.getProgram().getSelectIncidentDatesInFuture(), mForm.getProgram().getEnrollmentDateLabel(),
+        EnrollmentDateSetterHelper.createEnrollment(mForm.getTrackedEntityInstance(), this,
+                getActivity(), mForm.getProgram().
+                        getDisplayIncidentDate(),
+                mForm.getProgram().getSelectEnrollmentDatesInFuture(),
+                mForm.getProgram().getSelectIncidentDatesInFuture(),
+                mForm.getProgram().getEnrollmentDateLabel(),
                 mForm.getProgram().getIncidentDateLabel());
     }
 
     @Override
-    public void showEnrollmentFragment(TrackedEntityInstance trackedEntityInstance, DateTime enrollmentDate, DateTime incidentDate) {
+    public void showEnrollmentFragment(TrackedEntityInstance trackedEntityInstance,
+            DateTime enrollmentDate, DateTime incidentDate) {
         String enrollmentDateString = enrollmentDate.toString();
         String incidentDateString = null;
         if (incidentDate != null) {
             incidentDateString = incidentDate.toString();
         }
         if (trackedEntityInstance == null) {
-            HolderActivity.navigateToEnrollmentDataEntryFragment(getActivity(), mState.getOrgUnitId(), mState.getProgramId(), enrollmentDateString, incidentDateString);
+            HolderActivity.navigateToEnrollmentDataEntryFragment(getActivity(),
+                    mState.getOrgUnitId(), mState.getProgramId(), enrollmentDateString,
+                    incidentDateString);
         } else {
-            HolderActivity.navigateToEnrollmentDataEntryFragment(getActivity(), mState.getOrgUnitId(), mState.getProgramId(), trackedEntityInstance.getLocalId(), enrollmentDateString, incidentDateString);
+            HolderActivity.navigateToEnrollmentDataEntryFragment(getActivity(),
+                    mState.getOrgUnitId(), mState.getProgramId(),
+                    trackedEntityInstance.getLocalId(), enrollmentDateString, incidentDateString);
         }
     }
 
     public void showDataEntryFragment(Event event, String programStage) {
         Bundle args = getArguments();
         if (event == null) {
-            HolderActivity.navigateToDataEntryFragment(getActivity(), args.getString(ORG_UNIT_ID), args.getString(PROGRAM_ID), programStage, mForm.getEnrollment().getLocalId());
+            HolderActivity.navigateToDataEntryFragment(getActivity(), args.getString(ORG_UNIT_ID),
+                    args.getString(PROGRAM_ID), programStage, mForm.getEnrollment().getLocalId());
         } else {
-            HolderActivity.navigateToDataEntryFragment(getActivity(), args.getString(ORG_UNIT_ID), args.getString(PROGRAM_ID), programStage,
+            HolderActivity.navigateToDataEntryFragment(getActivity(), args.getString(ORG_UNIT_ID),
+                    args.getString(PROGRAM_ID), programStage,
                     mForm.getEnrollment().getLocalId(), event.getLocalId());
         }
     }
 
     public void completeEnrollment() {
         if (mForm == null || mForm.getEnrollment() == null) {
-            Log.i("ENROLLMENT", "Unable to complete enrollment. mForm or mForm.getEnrollment() is null");
+            Log.i("ENROLLMENT",
+                    "Unable to complete enrollment. mForm or mForm.getEnrollment() is null");
             return;
         }
         mForm.getEnrollment().setStatus(Enrollment.COMPLETED);
@@ -882,7 +915,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
 
     public void terminateEnrollment() {
         if (mForm == null || mForm.getEnrollment() == null) {
-            Log.i("ENROLLMENT", "Unable to terminate enrollment. mForm or mForm.getEnrollment() is null");
+            Log.i("ENROLLMENT",
+                    "Unable to terminate enrollment. mForm or mForm.getEnrollment() is null");
             return;
         }
         mForm.getEnrollment().setStatus(Enrollment.CANCELLED);
@@ -999,8 +1033,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 break;
             }
             case R.id.enrollmentstatus: {
-                if (mForm != null && mForm.getEnrollment() != null)
+                if (mForm != null && mForm.getEnrollment() != null) {
                     showStatusDialog(mForm.getEnrollment());
+                }
                 break;
             }
             case R.id.pullrelationshipbutton: {
@@ -1019,8 +1054,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
 
     private void refreshRelationships() {
         Context context = getActivity().getBaseContext();
-        Toast.makeText(context, getString(org.hisp.dhis.android.sdk.R.string.refresh_relations), Toast.LENGTH_SHORT).show();
-        if(mForm!=null && mForm.getTrackedEntityInstance()!=null) {
+        Toast.makeText(context, getString(org.hisp.dhis.android.sdk.R.string.refresh_relations),
+                Toast.LENGTH_SHORT).show();
+        if (mForm != null && mForm.getTrackedEntityInstance() != null) {
             refreshTrackedEntityRelationships(mForm.getTrackedEntityInstance().getUid());
         }
     }
@@ -1030,7 +1066,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     private Enrollment getLastEnrollmentForTrackedEntityInstance() {
-        List<Enrollment> enrollments = TrackerController.getEnrollments(mForm.getTrackedEntityInstance());
+        List<Enrollment> enrollments = TrackerController.getEnrollments(
+                mForm.getTrackedEntityInstance());
         EnrollmentDateComparator comparator = new EnrollmentDateComparator();
         Collections.reverseOrder(comparator);
         Collections.sort(enrollments, comparator);
@@ -1047,26 +1084,32 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     private void editEnrollmentDates() {
-        if(mForm != null && mForm.getEnrollment() != null ) {
-            HolderActivity.navigateToEnrollmentDateFragment(getActivity(), mForm.getEnrollment().getLocalId());
+        if (mForm != null && mForm.getEnrollment() != null) {
+            HolderActivity.navigateToEnrollmentDateFragment(getActivity(),
+                    mForm.getEnrollment().getLocalId());
         }
 
     }
 
     private void editTrackedEntityInstanceProfile() {
         HolderActivity.navigateToTrackedEntityInstanceProfileFragment(getActivity(), getArguments().
-                getLong(TRACKEDENTITYINSTANCE_ID), getArguments().getString(PROGRAM_ID), mForm.getEnrollment().getLocalId());
+                        getLong(TRACKEDENTITYINSTANCE_ID), getArguments().getString(PROGRAM_ID),
+                mForm.getEnrollment().getLocalId());
     }
 
     private void showAddRelationshipFragment() {
         if (mForm == null || mForm.getTrackedEntityInstance() == null) return;
-        RegisterRelationshipDialogFragment fragment = RegisterRelationshipDialogFragment.newInstance(mForm.getTrackedEntityInstance().getLocalId());
+        RegisterRelationshipDialogFragment fragment =
+                RegisterRelationshipDialogFragment.newInstance(
+                        mForm.getTrackedEntityInstance().getLocalId());
         fragment.show(getChildFragmentManager(), CLASS_TAG);
     }
 
     void displayKeyValuePair(ProgramRuleAction programRuleAction) {
-        FlowLayout programIndicatorLayout = (FlowLayout) programIndicatorCardView.findViewById(R.id.keyvaluelayout);
-        KeyValueView keyValueView = new KeyValueView(programRuleAction.getContent(), ProgramRuleService.getCalculatedConditionValue(programRuleAction.getData()));
+        FlowLayout programIndicatorLayout = (FlowLayout) programIndicatorCardView.findViewById(
+                R.id.keyvaluelayout);
+        KeyValueView keyValueView = new KeyValueView(programRuleAction.getContent(),
+                ProgramRuleService.getCalculatedConditionValue(programRuleAction.getData()));
         FlowLayout.LayoutParams layoutParams = new FlowLayout.LayoutParams(10, 10);
         View view = keyValueView.getView(getLayoutInflater(getArguments()), programIndicatorLayout);
         view.setLayoutParams(layoutParams);
@@ -1074,9 +1117,12 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     void displayText(ProgramRuleAction programRuleAction) {
-        LinearLayout programIndicatorLayout = (LinearLayout) programIndicatorCardView.findViewById(R.id.textlayout);
-        PlainTextRow textRow = new PlainTextRow(ProgramRuleService.getCalculatedConditionValue(programRuleAction.getData()));
-        View view = textRow.getView(getChildFragmentManager(), getLayoutInflater(getArguments()), null, programIndicatorLayout);
+        LinearLayout programIndicatorLayout = (LinearLayout) programIndicatorCardView.findViewById(
+                R.id.textlayout);
+        PlainTextRow textRow = new PlainTextRow(
+                ProgramRuleService.getCalculatedConditionValue(programRuleAction.getData()));
+        View view = textRow.getView(getChildFragmentManager(), getLayoutInflater(getArguments()),
+                null, programIndicatorLayout);
         view.findViewById(R.id.text_label).setVisibility(View.GONE);
         view.findViewById(R.id.detailed_info_button_layout).setVisibility(View.GONE);
         programIndicatorLayout.addView(view);
@@ -1108,7 +1154,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     public void onRefresh() {
         if (isAdded()) {
             Context context = getActivity().getBaseContext();
-            Toast.makeText(context, getString(org.hisp.dhis.android.sdk.R.string.syncing), Toast.LENGTH_SHORT).show();
+            Toast.makeText(context, getString(org.hisp.dhis.android.sdk.R.string.syncing),
+                    Toast.LENGTH_SHORT).show();
             synchronize();
         }
     }
@@ -1135,7 +1182,7 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     public void synchronize() {
-        if(mForm != null) {
+        if (mForm != null) {
             sendTrackedEntityInstance(mForm.getTrackedEntityInstance());
         }
     }
@@ -1146,7 +1193,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 ResourceType.TRACKEDENTITYINSTANCE) {
             @Override
             public Object execute() {
-                TrackerController.refreshRelationsByTrackedEntity(DhisController.getInstance().getDhisApi(), trackedEntityInstance);
+                TrackerController.refreshRelationsByTrackedEntity(
+                        DhisController.getInstance().getDhisApi(), trackedEntityInstance);
                 return new Object();
             }
         });
@@ -1157,7 +1205,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 ResourceType.TRACKEDENTITYINSTANCE) {
             @Override
             public Object execute() {
-                TrackerController.sendTrackedEntityInstanceChanges(DhisController.getInstance().getDhisApi(), trackedEntityInstance, true);
+                TrackerController.sendTrackedEntityInstanceChanges(
+                        DhisController.getInstance().getDhisApi(), trackedEntityInstance, true);
                 return new Object();
             }
         });

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -634,56 +634,8 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                         continue;
                     }
 
-                    /* Creating a string to display as name of relative from attributes */
-                    String relativeString = "";
-                    if (relative != null && relative.getAttributes() != null) {
-                        List<Enrollment> enrollments = TrackerController.getEnrollments(relative);
-                        List<TrackedEntityAttribute> attributesToShow = new ArrayList<>();
-                        List<TrackedEntityAttributeValue> attributes = TrackerController.getVisibleTrackedEntityAttributeValues(relative.getLocalId());
-                        for (int i = 0; i < attributes.size() && i < 2; i++) {
-                            relativeString += attributes.get(i).getValue() + " ";
-                        }
-                        if(attributes.size() == 0) {
-                            if (enrollments != null && !enrollments.isEmpty()) {
-                                Program program = null;
-                                for (Enrollment e : enrollments) {
-                                    if (e != null && e.getProgram() != null
-                                            && e.getProgram().getProgramTrackedEntityAttributes()
-                                            != null) {
-                                        program = e.getProgram();
-                                        break;
-                                    }
-                                }
-                                List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes =
-                                        program.getProgramTrackedEntityAttributes();
-                                for (int i = 0; i < programTrackedEntityAttributes.size() && i < 2;
-                                        i++) {
-                                    attributesToShow.add(programTrackedEntityAttributes.get(
-                                            i).getTrackedEntityAttribute());
-                                }
-                                for (int i = 0; i < attributesToShow.size() && i < 2; i++) {
-                                    TrackedEntityAttributeValue av =
-                                            TrackerController.getTrackedEntityAttributeValue(
-                                                    attributesToShow.get(i).getUid(),
-                                                    relative.getLocalId());
-                                    if (av != null && av.getValue() != null) {
-                                        relativeString += av.getValue() + " ";
-                                    }
-                                }
-                            } else {
-                                for (int i = 0; i < relative.getAttributes().size() && i < 2; i++) {
-                                    if (relative.getAttributes().get(i) != null
-                                            && relative.getAttributes().get(i).getValue() != null) {
-                                        relativeString += relative.getAttributes().get(i).getValue()
-                                                + " ";
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    if (relativeString.isEmpty()) {
-                        relativeString = getString(R.string.unknown);
-                    }
+                    String relativeString = getRelativeString(relative);
+
                     relativeLabel.setText(relativeString);
 
                     ll.setOnClickListener(new View.OnClickListener() {
@@ -707,6 +659,61 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 }
             }
         }
+    }
+
+    private String getRelativeString(TrackedEntityInstance relative) {
+
+        String relativeString = "";
+
+        if (relative != null && relative.getAttributes() != null) {
+            List<Enrollment> enrollments = TrackerController.getEnrollments(relative);
+            List<TrackedEntityAttribute> attributesToShow = new ArrayList<>();
+            List<TrackedEntityAttributeValue> attributes = TrackerController.getVisibleTrackedEntityAttributeValues(relative.getLocalId());
+            for (int i = 0; i < attributes.size() && i < 2; i++) {
+                relativeString += attributes.get(i).getValue() + " ";
+            }
+            if(attributes.size() == 0) {
+                if (enrollments != null && !enrollments.isEmpty()) {
+                    Program program = null;
+                    for (Enrollment e : enrollments) {
+                        if (e != null && e.getProgram() != null
+                                && e.getProgram().getProgramTrackedEntityAttributes()
+                                != null) {
+                            program = e.getProgram();
+                            break;
+                        }
+                    }
+                    List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes =
+                            program.getProgramTrackedEntityAttributes();
+                    for (int i = 0; i < programTrackedEntityAttributes.size() && i < 2;
+                            i++) {
+                        attributesToShow.add(programTrackedEntityAttributes.get(
+                                i).getTrackedEntityAttribute());
+                    }
+                    for (int i = 0; i < attributesToShow.size() && i < 2; i++) {
+                        TrackedEntityAttributeValue av =
+                                TrackerController.getTrackedEntityAttributeValue(
+                                        attributesToShow.get(i).getUid(),
+                                        relative.getLocalId());
+                        if (av != null && av.getValue() != null) {
+                            relativeString += av.getValue() + " ";
+                        }
+                    }
+                } else {
+                    for (int i = 0; i < relative.getAttributes().size() && i < 2; i++) {
+                        if (relative.getAttributes().get(i) != null
+                                && relative.getAttributes().get(i).getValue() != null) {
+                            relativeString += relative.getAttributes().get(i).getValue()
+                                    + " ";
+                        }
+                    }
+                }
+            }
+        }
+        if (relativeString.isEmpty()) {
+            relativeString = getString(R.string.unknown);
+        }
+        return relativeString;
     }
 
     public static void showConfirmDeleteRelationshipDialog(final Relationship relationship,

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -97,12 +97,10 @@ import org.hisp.dhis.android.sdk.utils.comparators.EnrollmentDateComparator;
 import org.hisp.dhis.android.sdk.utils.services.ProgramRuleService;
 import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.activities.HolderActivity;
-import org.hisp.dhis.android.trackercapture.fragments.programoverview
-        .registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
+import org.hisp.dhis.android.trackercapture.fragments.programoverview.registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.EnrollmentDateSetterHelper;
 import org.hisp.dhis.android.trackercapture.fragments.selectprogram.IEnroller;
-import org.hisp.dhis.android.trackercapture.fragments.selectprogram.dialogs
-        .ItemStatusDialogFragment;
+import org.hisp.dhis.android.trackercapture.fragments.selectprogram.dialogs.ItemStatusDialogFragment;
 import org.hisp.dhis.android.trackercapture.ui.adapters.ProgramAdapter;
 import org.hisp.dhis.android.trackercapture.ui.adapters.ProgramStageAdapter;
 import org.hisp.dhis.android.trackercapture.ui.rows.programoverview.OnProgramStageEventClick;
@@ -194,11 +192,7 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
-        Bundle argumentsBundle = new Bundle();
-        argumentsBundle.putBundle(EXTRA_ARGUMENTS, getArguments());
-        argumentsBundle.putBundle(EXTRA_SAVED_INSTANCE_STATE, savedInstanceState);
-        getLoaderManager().initLoader(LOADER_ID, argumentsBundle, this);
+        getLoaderManager().initLoader(LOADER_ID, getArguments(), this);
 
         mProgressBar.setVisibility(View.VISIBLE);
     }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -148,12 +148,14 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     private TextView enrollmentDateValue;
     private TextView incidentDateLabel;
     private TextView incidentDateValue;
+    private TextView noActiveEnrollment;
 
     private LinearLayout missingEnrollmentLayout;
     private FloatingActionButton newEnrollmentButton;
 
     private CardView profileCardView;
     private CardView enrollmentCardview;
+
     private CardView programIndicatorCardView;
 
     private ImageButton followupButton;
@@ -278,6 +280,7 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
         incidentDateValue = (TextView) header.findViewById(R.id.dateOfIncidentValue);
         profileCardView = (CardView) header.findViewById(R.id.profile_cardview);
         enrollmentCardview = (CardView) header.findViewById(R.id.enrollment_cardview);
+        noActiveEnrollment = (TextView) header.findViewById(R.id.noactiveenrollment);
         programIndicatorCardView = (CardView) header.findViewById(R.id.programindicators_cardview);
 
         completeButton = (Button) header.findViewById(R.id.complete);
@@ -753,10 +756,22 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     public void showNoActiveEnrollment(ProgramOverviewFragmentForm mForm) {
         enrollmentLayout.setVisibility(View.GONE);
 
-        if (mForm.getProgram() != null && !mForm.getProgram().getOnlyEnrollOnce()) {
-            missingEnrollmentLayout.setVisibility(View.VISIBLE);
-        } else {
-            missingEnrollmentLayout.setVisibility(View.GONE);
+        //start values
+        reOpenButton.setVisibility(View.VISIBLE);
+        newEnrollmentButton.setVisibility(View.VISIBLE);
+        noActiveEnrollment.setText(R.string.no_active_enrollment);
+
+        missingEnrollmentLayout.setVisibility(View.VISIBLE);
+        List<Enrollment> enrollments = TrackerController.getEnrollments(mForm.getProgram().getUid(),
+                mForm.getTrackedEntityInstance());
+        if(enrollments!=null && enrollments.size()>0) {
+            if (mForm.getProgram() != null && mForm.getProgram().getOnlyEnrollOnce()) {
+                newEnrollmentButton.setVisibility(View.GONE);
+                noActiveEnrollment.setText(R.string.enrollemnt_complete);
+            }
+        }
+        if(getLastEnrollmentForTrackedEntityInstance()==null){
+            reOpenButton.setVisibility(View.GONE);
         }
 
         //update profile view
@@ -959,9 +974,11 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
             }
             case R.id.re_open: {
                 Enrollment enrollment = getLastEnrollmentForTrackedEntityInstance();
-                enrollment.setStatus(Enrollment.ACTIVE);
-                enrollment.async().save();
-                refreshUi();
+                if(enrollment!=null) {
+                    enrollment.setStatus(Enrollment.ACTIVE);
+                    enrollment.async().save();
+                    refreshUi();
+                }
                 break;
             }
 
@@ -1030,7 +1047,10 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     }
 
     private Enrollment getLastEnrollmentForTrackedEntityInstance() {
-        List<Enrollment> enrollments = TrackerController.getEnrollments(mForm.getTrackedEntityInstance());
+        List<Enrollment> enrollments = TrackerController.getEnrollments(mForm.getProgram().getUid(), mForm.getTrackedEntityInstance());
+        if(enrollments==null || enrollments.size()==0) {
+            return null;
+        }
         EnrollmentDateComparator comparator = new EnrollmentDateComparator();
         Collections.reverseOrder(comparator);
         Collections.sort(enrollments, comparator);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
@@ -31,8 +31,8 @@ package org.hisp.dhis.android.trackercapture.fragments.programoverview;
 
 import android.content.Context;
 
-import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
+import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
 import org.hisp.dhis.android.sdk.persistence.models.Enrollment;
 import org.hisp.dhis.android.sdk.persistence.models.Event;
@@ -96,19 +96,20 @@ class ProgramOverviewFragmentQuery implements Query<ProgramOverviewFragmentForm>
         programOverviewFragmentForm.setEnrollment(activeEnrollment);
         programOverviewFragmentForm.setDateOfEnrollmentValue(Utils.removeTimeFromDateString(activeEnrollment.getEnrollmentDate()));
         programOverviewFragmentForm.setIncidentDateValue(Utils.removeTimeFromDateString(activeEnrollment.getIncidentDate()));
-        List<TrackedEntityAttributeValue> attributeValues = activeEnrollment.getAttributes();
-        if(attributeValues!=null) {
-            if(attributeValues.size() > 0) {
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues =
+                TrackerController.getVisibleTrackedEntityAttributeValues(trackedEntityInstance.getLocalId());
+        if(trackedEntityAttributeValues!=null) {
+            if(trackedEntityAttributeValues.size() > 0) {
                 programOverviewFragmentForm.setAttribute1Label(MetaDataController.
-                        getTrackedEntityAttribute(attributeValues.get(0).getTrackedEntityAttributeId()).
+                        getTrackedEntityAttribute(trackedEntityAttributeValues.get(0).getTrackedEntityAttributeId()).
                         getName());
-                programOverviewFragmentForm.setAttribute1Value(attributeValues.get(0).getValue());
+                programOverviewFragmentForm.setAttribute1Value(trackedEntityAttributeValues.get(0).getValue());
             }
-            if(attributeValues.size() > 1) {
+            if(trackedEntityAttributeValues.size() > 1) {
                 programOverviewFragmentForm.setAttribute2Label(MetaDataController.
-                        getTrackedEntityAttribute(attributeValues.get(1).getTrackedEntityAttributeId()).
+                        getTrackedEntityAttribute(trackedEntityAttributeValues.get(1).getTrackedEntityAttributeId()).
                         getName());
-                programOverviewFragmentForm.setAttribute2Value(attributeValues.get(1).getValue());
+                programOverviewFragmentForm.setAttribute2Value(trackedEntityAttributeValues.get(1).getValue());
             }
         }
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/selectprogramdialogfragment/SelectProgramDialogFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/selectprogramdialogfragment/SelectProgramDialogFragment.java
@@ -1,0 +1,294 @@
+/*
+ *  Copyright (c) 2016, University of Oslo
+ *  * All rights reserved.
+ *  *
+ *  * Redistribution and use in source and binary forms, with or without
+ *  * modification, are permitted provided that the following conditions are met:
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *  * list of conditions and the following disclaimer.
+ *  *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  * this list of conditions and the following disclaimer in the documentation
+ *  * and/or other materials provided with the distribution.
+ *  * Neither the name of the HISP project nor the names of its contributors may
+ *  * be used to endorse or promote products derived from this software without
+ *  * specific prior written permission.
+ *  *
+ *  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ *  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package org.hisp.dhis.android.trackercapture.fragments.programoverview.selectprogramdialogfragment;
+
+
+
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentManager;
+import android.util.Pair;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import org.hisp.dhis.android.sdk.R;
+import org.hisp.dhis.android.sdk.ui.dialogs.AutoCompleteDialogFragment;
+import org.hisp.dhis.android.sdk.ui.dialogs.OrgUnitDialogFragment;
+import org.hisp.dhis.android.sdk.ui.dialogs.ProgramDialogFragment;
+import org.hisp.dhis.android.sdk.ui.dialogs.UpcomingEventsDialogFilter;
+import org.hisp.dhis.android.sdk.ui.fragments.selectprogram.SelectProgramFragmentPreferences;
+import org.hisp.dhis.android.sdk.ui.fragments.selectprogram.SelectProgramFragmentState;
+import org.hisp.dhis.android.sdk.ui.views.CardTextViewButton;
+import org.hisp.dhis.android.sdk.ui.views.FloatingActionButton;
+import org.hisp.dhis.android.sdk.utils.api.ProgramType;
+import org.hisp.dhis.android.trackercapture.activities.HolderActivity;
+import org.hisp.dhis.android.trackercapture.fragments.programoverview
+        .registerrelationshipdialogfragment.RegisterRelationshipDialogFragment;
+import org.hisp.dhis.android.trackercapture.fragments.programoverview
+        .registerrelationshipdialogfragment.RelationshipTypesDialogFragment;
+
+import java.util.Arrays;
+
+public class SelectProgramDialogFragment extends DialogFragment
+        implements View.OnClickListener  ,AutoCompleteDialogFragment.OnOptionSelectedListener  {
+    private static final String TAG = SelectProgramDialogFragment.class.getSimpleName();
+
+    protected final String STATE = "state:SelectProgramFragment";
+
+    protected CardTextViewButton mOrgUnitButton;
+    protected CardTextViewButton mProgramButton;
+    private FloatingActionButton searchAndDownloadButton;
+    private TextView mDialogLabel;
+
+    protected SelectProgramFragmentState mState;
+    protected SelectProgramFragmentPreferences mPrefs;
+    private static RegisterRelationshipDialogFragment.CallBack mCallBack;
+
+    private static final String EXTRA_TRACKEDENTITYINSTANCEID = "extra:trackedEntityInstanceId";
+    private static final String EXTRA_ARGUMENTS = "extra:Arguments";
+    private static final String EXTRA_SAVED_INSTANCE_STATE = "extra:savedInstanceState";
+
+    public static SelectProgramDialogFragment newInstance(long trackedEntityInstanceId, RegisterRelationshipDialogFragment.CallBack callBack) {
+        mCallBack=callBack;
+        SelectProgramDialogFragment dialogFragment = new SelectProgramDialogFragment();
+        Bundle args = new Bundle();
+
+        args.putLong(EXTRA_TRACKEDENTITYINSTANCEID, trackedEntityInstanceId);
+        dialogFragment.setArguments(args);
+        return dialogFragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setStyle(DialogFragment.STYLE_NO_TITLE,
+                R.style.Theme_AppCompat_Light_Dialog);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        getDialog().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
+
+        return inflater.inflate(org.hisp.dhis.android.trackercapture.R.layout.dialog_fragment_selection_program, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        mPrefs = new SelectProgramFragmentPreferences(
+                getActivity().getApplicationContext());
+        searchAndDownloadButton  = (FloatingActionButton) view
+                .findViewById(org.hisp.dhis.android.trackercapture.R.id.search_and_download_button);
+        searchAndDownloadButton.setOnClickListener(this);
+
+        ImageView closeDialogButton = (ImageView) view
+                .findViewById(R.id.close_dialog_button);
+        closeDialogButton.setOnClickListener(this);
+        mDialogLabel = (TextView) view
+                .findViewById(R.id.dialog_label);
+        setDialogLabel(org.hisp.dhis.android.trackercapture.R.string.download_entities_title);
+
+        setStandardBottons(view);
+
+        setState(savedInstanceState);
+    }
+
+    private void setState(Bundle savedInstanceState) {
+
+        if (savedInstanceState != null &&
+                savedInstanceState.getParcelable(STATE) != null) {
+            mState = savedInstanceState.getParcelable(STATE);
+        }
+
+        if (mState == null) {
+            // restoring last selection of program
+            Pair<String, String> orgUnit = mPrefs.getOrgUnit();
+            Pair<String, String> program = mPrefs.getProgram();
+            Pair<String, String> filter = mPrefs.getFilter();
+            mState = new SelectProgramFragmentState();
+            if (orgUnit != null) {
+                mState.setOrgUnit(orgUnit.first, orgUnit.second);
+                if (program != null) {
+                    mState.setProgram(program.first, program.second);
+                }
+                if(filter != null) {
+                    mState.setFilter(filter.first, filter.second);
+                }
+                else {
+                    mState.setFilter("0", Arrays.asList(UpcomingEventsDialogFilter.Type.values()).get(0).toString());
+                }
+
+
+            }
+        }
+
+        onRestoreState(true);
+    }
+
+    private void setStandardBottons(View view) {
+        mOrgUnitButton = (CardTextViewButton) view.findViewById(R.id.select_organisation_unit);
+        mProgramButton = (CardTextViewButton) view.findViewById(R.id.select_program);
+
+        mOrgUnitButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                OrgUnitDialogFragment fragment = OrgUnitDialogFragment
+                        .newInstance(SelectProgramDialogFragment.this, getProgramTypes());
+                fragment.show(getChildFragmentManager());
+            }
+        });
+        mProgramButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ProgramDialogFragment fragment = ProgramDialogFragment
+                        .newInstance(SelectProgramDialogFragment.this, mState.getOrgUnitId(),
+                                getProgramTypes());
+                fragment.show(getChildFragmentManager());
+            }
+        });
+
+        mOrgUnitButton.setEnabled(true);
+        mProgramButton.setEnabled(false);
+    }
+
+    /* This method must be called only after onViewCreated() */
+    public void setDialogLabel(int resourceId) {
+        if (mDialogLabel != null) {
+            mDialogLabel.setText(resourceId);
+        }
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState)
+    {
+        super.onActivityCreated(savedInstanceState);
+        Bundle argumentsBundle = new Bundle();
+        argumentsBundle.putBundle(EXTRA_ARGUMENTS, getArguments());
+        argumentsBundle.putBundle(EXTRA_SAVED_INSTANCE_STATE, savedInstanceState);
+    }
+
+    public void show(FragmentManager fragmentManager) {
+        show(fragmentManager, TAG);
+    }
+
+    @Override
+    public void onClick(View v) {
+        if(v.getId() == org.hisp.dhis.android.trackercapture.R.id.relationshiptypebutton ) {
+            RelationshipTypesDialogFragment fragment = RelationshipTypesDialogFragment
+                    .newInstance(this);
+            fragment.show(getChildFragmentManager());
+        } else if(v.getId() == R.id.close_dialog_button) {
+            dismiss();
+        } else if(v.getId() == org.hisp.dhis.android.trackercapture.R.id.search_and_download_button){
+            HolderActivity.navigateToOnlineSearchFragment(getActivity(), mState.getProgramId(), mState.getOrgUnitId(), true, mCallBack);
+            dismiss();
+        }
+    }
+
+    @Override
+    public void onOptionSelected(int dialogId, int position, String id, String name) {
+        switch (dialogId) {
+            case OrgUnitDialogFragment.ID: {
+                onUnitSelected(id, name);
+                break;
+            }
+            case ProgramDialogFragment.ID: {
+                onProgramSelected(id, name);
+                break;
+            }
+        }
+    }
+
+    public void onRestoreState(boolean hasUnits) {
+        mOrgUnitButton.setEnabled(hasUnits);
+        if (!hasUnits) {
+            return;
+        }
+
+        SelectProgramFragmentState backedUpState = new SelectProgramFragmentState(mState);
+        if (!backedUpState.isOrgUnitEmpty()) {
+            onUnitSelected(
+                    backedUpState.getOrgUnitId(),
+                    backedUpState.getOrgUnitLabel()
+            );
+
+            if (!backedUpState.isProgramEmpty()) {
+                onProgramSelected(
+                        backedUpState.getProgramId(),
+                        backedUpState.getProgramName()
+                );
+            }
+        }
+
+    }
+
+    public void onUnitSelected(String orgUnitId, String orgUnitLabel) {
+        mOrgUnitButton.setText(orgUnitLabel);
+        mProgramButton.setEnabled(true);
+
+        mState.setOrgUnit(orgUnitId, orgUnitLabel);
+        mState.resetProgram();
+
+        mPrefs.putOrgUnit(new Pair<>(orgUnitId, orgUnitLabel));
+        mPrefs.putProgram(null);
+
+        handleViews(0);
+    }
+
+    public void onProgramSelected(String programId, String programName) {
+        mProgramButton.setText(programName);
+
+        mState.setProgram(programId, programName);
+        mPrefs.putProgram(new Pair<>(programId, programName));
+        handleViews(1);
+
+        // this call will trigger onCreateLoader method
+    }
+
+    protected ProgramType[] getProgramTypes() {
+        return new ProgramType[]{
+                ProgramType.WITH_REGISTRATION
+        };
+    }
+
+    protected void handleViews(int level) {
+        switch (level) {
+            case 0:
+                searchAndDownloadButton.hide();
+                break;
+            case 1:
+                searchAndDownloadButton.show();
+        }
+    }
+}

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/selectprogramdialogfragment/SelectProgramDialogFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/selectprogramdialogfragment/SelectProgramDialogFragment.java
@@ -119,7 +119,7 @@ public class SelectProgramDialogFragment extends DialogFragment
                 .findViewById(R.id.dialog_label);
         setDialogLabel(org.hisp.dhis.android.trackercapture.R.string.download_entities_title);
 
-        setStandardBottons(view);
+        setOUAndProgramButtons(view);
 
         setState(savedInstanceState);
     }
@@ -156,7 +156,7 @@ public class SelectProgramDialogFragment extends DialogFragment
         onRestoreState(true);
     }
 
-    private void setStandardBottons(View view) {
+    private void setOUAndProgramButtons(View view) {
         mOrgUnitButton = (CardTextViewButton) view.findViewById(R.id.select_organisation_unit);
         mProgramButton = (CardTextViewButton) view.findViewById(R.id.select_program);
 
@@ -263,7 +263,7 @@ public class SelectProgramDialogFragment extends DialogFragment
         mPrefs.putOrgUnit(new Pair<>(orgUnitId, orgUnitLabel));
         mPrefs.putProgram(null);
 
-        handleViews(0);
+        searchAndDownloadButton.hide();
     }
 
     public void onProgramSelected(String programId, String programName) {
@@ -271,7 +271,7 @@ public class SelectProgramDialogFragment extends DialogFragment
 
         mState.setProgram(programId, programName);
         mPrefs.putProgram(new Pair<>(programId, programName));
-        handleViews(1);
+        searchAndDownloadButton.show();
 
         // this call will trigger onCreateLoader method
     }
@@ -280,15 +280,5 @@ public class SelectProgramDialogFragment extends DialogFragment
         return new ProgramType[]{
                 ProgramType.WITH_REGISTRATION
         };
-    }
-
-    protected void handleViews(int level) {
-        switch (level) {
-            case 0:
-                searchAndDownloadButton.hide();
-                break;
-            case 1:
-                searchAndDownloadButton.show();
-        }
     }
 }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragment.java
@@ -176,7 +176,7 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
         super.onViewCreated(view, savedInstanceState);
 
         if(getActivity() instanceof AppCompatActivity) {
-            getActionBar().setDisplayShowTitleEnabled(false);
+            getActionBar().setTitle(getString(R.string.local_search));
             getActionBar().setDisplayHomeAsUpEnabled(true);
             getActionBar().setHomeButtonEnabled(true);
         }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragmentFormQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragmentFormQuery.java
@@ -62,7 +62,7 @@ public class LocalSearchFragmentFormQuery implements Query<LocalSearchFragmentFo
             }
             Row row = DataEntryRowFactory.createDataEntryView(ptea.getMandatory(),
                     ptea.getAllowFutureDate(), trackedEntityAttribute.getOptionSet(),
-                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false);
+                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false,program.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         form.setTrackedEntityAttributeValues(values);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchResultFragmentFormQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchResultFragmentFormQuery.java
@@ -2,7 +2,6 @@ package org.hisp.dhis.android.trackercapture.fragments.search;
 
 import android.content.Context;
 
-import com.raizlabs.android.dbflow.sql.builder.Condition;
 import com.raizlabs.android.dbflow.sql.language.Select;
 import com.raizlabs.android.dbflow.sql.queriable.StringQuery;
 
@@ -305,8 +304,11 @@ public class LocalSearchResultFragmentFormQuery implements Query<LocalSearchResu
         if(attributesIdsUsedInQueryIterator.hasNext()) {
             firstId = attributesIdsUsedInQueryIterator.next();
         } else {
-            //no values have been used in the query
-            return null;
+            //no values have been used in the query show with no filter
+            return "SELECT * FROM " + TrackedEntityInstance.class.getSimpleName() + " WHERE "
+                    + TrackedEntityInstance$Table.TRACKEDENTITYINSTANCE + " IN (SELECT " +
+                    TrackedEntityAttributeValue$Table.TRACKEDENTITYINSTANCEID + " FROM " +
+                    TrackedEntityAttributeValue.class.getSimpleName() + ")";
         }
         String firstValue;
         TrackedEntityAttribute firstTrackedEntityAttribute = trackedEntityAttributeMap.get(firstId);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
@@ -186,6 +186,7 @@ public class OnlineSearchFragment extends Fragment implements View.OnClickListen
         argumentsBundle.putBundle(EXTRA_ARGUMENTS, getArguments());
         argumentsBundle.putBundle(EXTRA_SAVED_INSTANCE_STATE, savedInstanceState);
         getLoaderManager().initLoader(LOADER_ID, argumentsBundle, this);
+        getActionBar().setTitle(getString(R.string.online_query_tracked_entity_instances));
     }
 
     @Override

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
@@ -59,11 +59,13 @@ public class OnlineSearchFragment extends Fragment implements View.OnClickListen
     private ListView mListView;
     private int mDialogId;
     private View progressBar;
+    private boolean backNavigation;
 
     public static final String EXTRA_PROGRAM = "extra:trackedEntityAttributes";
     public static final String EXTRA_ORGUNIT = "extra:orgUnit";
     public static final String EXTRA_DETAILED = "extra:detailed";
     public static final String EXTRA_ARGUMENTS = "extra:Arguments";
+    public static final String EXTRA_NAVIGATION = "extra:Navigation";
     public static final String EXTRA_SAVED_INSTANCE_STATE = "extra:savedInstanceState";
 
     public static OnlineSearchFragment newInstance(String program, String orgUnit) {
@@ -199,6 +201,7 @@ public class OnlineSearchFragment extends Fragment implements View.OnClickListen
             Bundle fragmentArguments = args.getBundle(EXTRA_ARGUMENTS);
             String programId = fragmentArguments.getString(EXTRA_PROGRAM);
             String orgUnitId = fragmentArguments.getString(EXTRA_ORGUNIT);
+            backNavigation = fragmentArguments.getBoolean(EXTRA_NAVIGATION);
 
             return new DbLoader<>(
                     getActivity().getBaseContext(), modelsToTrack, new OnlineSearchFragmentQuery(
@@ -370,19 +373,19 @@ public class OnlineSearchFragment extends Fragment implements View.OnClickListen
                 }
 
                 // showTrackedEntityInstanceQueryResultDialog(fragmentManager, trackedEntityInstancesQueryResult, orgUnit);
-                showOnlineSearchResultFragment(trackedEntityInstancesQueryResult, orgUnit, program);
+                showOnlineSearchResultFragment(trackedEntityInstancesQueryResult, orgUnit, program, backNavigation);
                 return new Object();
             }
         });
     }
 
-    public void showOnlineSearchResultFragment(final List<TrackedEntityInstance> trackedEntityInstances, final String orgUnit, final String programId) {
+    public void showOnlineSearchResultFragment(final List<TrackedEntityInstance> trackedEntityInstances, final String orgUnit, final String programId, final boolean backNavigation) {
         if (getActivity() != null && isAdded()) {
             getActivity().runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
                     progressBar.setVisibility(View.INVISIBLE);
-                    HolderActivity.navigateToOnlineSearchResultFragment(getActivity(), trackedEntityInstances, orgUnit, programId);
+                    HolderActivity.navigateToOnlineSearchResultFragment(getActivity(), trackedEntityInstances, orgUnit, programId, backNavigation);
                 }
             });
         }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
@@ -188,7 +188,7 @@ public class OnlineSearchFragment extends Fragment implements View.OnClickListen
         argumentsBundle.putBundle(EXTRA_ARGUMENTS, getArguments());
         argumentsBundle.putBundle(EXTRA_SAVED_INSTANCE_STATE, savedInstanceState);
         getLoaderManager().initLoader(LOADER_ID, argumentsBundle, this);
-        getActionBar().setTitle(getString(R.string.online_query_tracked_entity_instances));
+        getActionBar().setTitle(getString(R.string.download_entities_title));
     }
 
     @Override

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragmentQuery.java
@@ -63,7 +63,7 @@ public class OnlineSearchFragmentQuery implements Query<OnlineSearchFragmentForm
 
             Row row = DataEntryRowFactory.createDataEntryView(ptea.getMandatory(),
                     ptea.getAllowFutureDate(), trackedEntityAttribute.getOptionSet(),
-                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false);
+                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false, program.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         form.setTrackedEntityAttributeValues(values);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
@@ -385,17 +385,8 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
 
                 if (downloadedTrackedEntityInstances != null && downloadedTrackedEntityInstances.size() == 1) {
                     if (downloadedEnrollments != null) {
-                        Enrollment activeEnrollment = null;
-                        if (downloadedEnrollments.size() == 1) {
-                            activeEnrollment = downloadedEnrollments.get(0);
-                        } else {
-                            for (Enrollment enrollment : downloadedEnrollments) {
-                                if (enrollment.getProgram().getUid().equals(programId)) {
-                                    activeEnrollment = enrollment;
-                                    break;
-                                }
-                            }
-                        }
+                        Enrollment activeEnrollment = getActiveEnrollmentByProgram(programId);
+
                         final Enrollment enrollment = activeEnrollment;
                         if (enrollment != null) {
                             final TrackedEntityInstance trackedEntityInstance =
@@ -431,7 +422,19 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
                 return new Object();
             }
         });
+    }
 
+    private Enrollment getActiveEnrollmentByProgram (String programId){
+        Enrollment activeEnrollment = null;
+
+        for (Enrollment enrollment : downloadedEnrollments) {
+            if (enrollment.getProgram().getUid().equals(programId)) {
+                activeEnrollment = enrollment;
+                break;
+            }
+        }
+
+        return activeEnrollment;
     }
 
     @Subscribe

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.android.sdk.ui.fragments.progressdialog.ProgressDialogFragm
 import org.hisp.dhis.android.sdk.utils.UiUtils;
 import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.activities.HolderActivity;
-import org.joda.time.DateTime;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -342,7 +341,7 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
             @Override
             public Object execute() throws APIException {
                 SynchronisationStateHandler.getInstance().changeState(true);
-                List<TrackedEntityInstance> trackedEntityInstances = TrackerController.getTrackedEntityInstancesDataFromServer(DhisController.getInstance().getDhisApi(), getSelectedTrackedEntityInstances(), false, true);
+                List<TrackedEntityInstance> trackedEntityInstances = TrackerController.getTrackedEntityInstancesDataFromServer(DhisController.getInstance().getDhisApi(), getSelectedTrackedEntityInstances(), true, true);
 
                 if (trackedEntityInstances != null) {
                     if (downloadedTrackedEntityInstances == null) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
@@ -342,7 +342,7 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
             @Override
             public Object execute() throws APIException {
                 SynchronisationStateHandler.getInstance().changeState(true);
-                List<TrackedEntityInstance> trackedEntityInstances = TrackerController.getTrackedEntityInstancesDataFromServer(DhisController.getInstance().getDhisApi(), getSelectedTrackedEntityInstances(), false);
+                List<TrackedEntityInstance> trackedEntityInstances = TrackerController.getTrackedEntityInstancesDataFromServer(DhisController.getInstance().getDhisApi(), getSelectedTrackedEntityInstances(), false, true);
 
                 if (trackedEntityInstances != null) {
                     if (downloadedTrackedEntityInstances == null) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
@@ -137,7 +137,7 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
             if(!backNavigation) {
                 getActivity().finish();
             }
-            initiateLoading(activity);
+            initiateLoading(activity, programId);
 
         } else if (id == android.R.id.home) {
             getActivity().finish();
@@ -334,7 +334,7 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
      * When it is done it will either display ProgramOverviewFragment if only one TEI and one Enrollment
      * is downloaded
      */
-    public void initiateLoading(final Activity activity) {
+    public void initiateLoading(final Activity activity, final String programId) {
 
         mAdapter.swapData(null);
         filterButton.setVisibility(View.INVISIBLE);
@@ -384,20 +384,34 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
 
 
                 if (downloadedTrackedEntityInstances != null && downloadedTrackedEntityInstances.size() == 1) {
-                    if (downloadedEnrollments != null && downloadedEnrollments.size() == 1) {
-                        final TrackedEntityInstance trackedEntityInstance = downloadedTrackedEntityInstances.get(0);
-                        final Enrollment enrollment = downloadedEnrollments.get(0);
-
-                        if(!backNavigation) {
-                            activity.runOnUiThread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    HolderActivity.navigateToProgramOverviewFragment(activity,
-                                            orgUnitId,
-                                            enrollment.getProgram().getUid(),
-                                            trackedEntityInstance.getLocalId());
+                    if (downloadedEnrollments != null) {
+                        Enrollment activeEnrollment = null;
+                        if (downloadedEnrollments.size() == 1) {
+                            activeEnrollment = downloadedEnrollments.get(0);
+                        } else {
+                            for (Enrollment enrollment : downloadedEnrollments) {
+                                if (enrollment.getProgram().getUid().equals(programId)) {
+                                    activeEnrollment = enrollment;
+                                    break;
                                 }
-                            });
+                            }
+                        }
+                        final Enrollment enrollment = activeEnrollment;
+                        if (enrollment != null) {
+                            final TrackedEntityInstance trackedEntityInstance =
+                                    downloadedTrackedEntityInstances.get(0);
+
+                            if (!backNavigation) {
+                                activity.runOnUiThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        HolderActivity.navigateToProgramOverviewFragment(activity,
+                                                orgUnitId,
+                                                enrollment.getProgram().getUid(),
+                                                trackedEntityInstance.getLocalId());
+                                    }
+                                });
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
@@ -21,6 +21,7 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.ListView;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.squareup.otto.Subscribe;
@@ -44,6 +45,7 @@ import org.hisp.dhis.android.sdk.ui.activities.SynchronisationStateHandler;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.AbsTextWatcher;
 import org.hisp.dhis.android.sdk.ui.dialogs.QueryTrackedEntityInstancesResultDialogAdapter;
 import org.hisp.dhis.android.sdk.ui.fragments.progressdialog.ProgressDialogFragment;
+import org.hisp.dhis.android.sdk.ui.views.FontEditText;
 import org.hisp.dhis.android.sdk.utils.UiUtils;
 import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.activities.HolderActivity;
@@ -70,12 +72,17 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
     private String orgUnitId;
     private String programId;
     private Map<String, ProgramTrackedEntityAttribute> programTrackedEntityAttributeMap;
+    private boolean backNavigation;
+    private ProgressBar mProgressBar;
+    private FontEditText filterButton;
+    private Button searchButton;
 
     public static final String EXTRA_TRACKEDENTITYINSTANCESLIST = "extra:trackedEntityInstances";
     public static final String EXTRA_TRACKEDENTITYINSTANCESSELECTED = "extra:trackedEntityInstancesSelected";
     public static final String EXTRA_ORGUNIT = "extra:orgUnit";
     public static final String EXTRA_SELECTALL = "extra:selectAll";
     public static final String EXTRA_PROGRAM = "extra:Program";
+    public static final String EXTRA_NAVIGATION = "extra:Navigation";
 
     public static OnlineSearchResultFragment newInstance(List<TrackedEntityInstance> trackedEntityInstances, String orgUnit) {
         OnlineSearchResultFragment dialogFragment = new OnlineSearchResultFragment();
@@ -127,9 +134,10 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
         int id = item.getItemId();
         if (id == R.id.action_load_to_device) {
             Activity activity = getActivity();
-            getActivity().finish();
+            if(!backNavigation) {
+                getActivity().finish();
+            }
             initiateLoading(activity);
-
 
         } else if (id == android.R.id.home) {
             getActivity().finish();
@@ -148,7 +156,7 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
     public void onViewCreated(View view, Bundle savedInstanceState) {
         mListView = (ListView) view
                 .findViewById(org.hisp.dhis.android.sdk.R.id.simple_listview);
-
+        mProgressBar = (ProgressBar) view.findViewById(org.hisp.dhis.android.sdk.R.id.progress_bar);
         if (getActivity() instanceof AppCompatActivity) {
             getActionBar().setDisplayShowTitleEnabled(true);
             getActionBar().setDisplayHomeAsUpEnabled(true);
@@ -156,11 +164,18 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
         }
         programId = getArguments().getString(EXTRA_PROGRAM);
         orgUnitId = getArguments().getString(EXTRA_ORGUNIT);
+        backNavigation = getArguments().getBoolean(EXTRA_NAVIGATION);
         Program selectedProgram = MetaDataController.getProgram(programId);
         mFilter = (EditText) view
                 .findViewById(org.hisp.dhis.android.sdk.R.id.filter_options);
         mDialogLabel = (TextView) view
                 .findViewById(org.hisp.dhis.android.sdk.R.id.dialog_label);
+
+
+        filterButton = (FontEditText) view
+                .findViewById(org.hisp.dhis.android.sdk.R.id.filter_options);
+        searchButton = (Button) view
+                .findViewById(org.hisp.dhis.android.sdk.R.id.teiqueryresult_selectall);
 
         UiUtils.hideKeyboard(getActivity());
 
@@ -321,10 +336,13 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
      */
     public void initiateLoading(final Activity activity) {
 
+        mAdapter.swapData(null);
+        filterButton.setVisibility(View.INVISIBLE);
+        searchButton.setVisibility(View.INVISIBLE);
+        mProgressBar.setVisibility(View.VISIBLE);
         Dhis2Application.getEventBus().post(
                 new OnTeiDownloadedEvent(OnTeiDownloadedEvent.EventType.START,
                         getSelectedTrackedEntityInstances().size()));
-
         Log.d(TAG, "loading: " + getSelectedTrackedEntityInstances().size());
         downloadedTrackedEntityInstances = new ArrayList<>();
         downloadedEnrollments = new ArrayList<>();
@@ -370,24 +388,32 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
                         final TrackedEntityInstance trackedEntityInstance = downloadedTrackedEntityInstances.get(0);
                         final Enrollment enrollment = downloadedEnrollments.get(0);
 
-
-                        activity.runOnUiThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                HolderActivity.navigateToProgramOverviewFragment(activity,
-                                        orgUnitId,
-                                        enrollment.getProgram().getUid(),
-                                        trackedEntityInstance.getLocalId());
-                            }
-                        });
-
+                        if(!backNavigation) {
+                            activity.runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    HolderActivity.navigateToProgramOverviewFragment(activity,
+                                            orgUnitId,
+                                            enrollment.getProgram().getUid(),
+                                            trackedEntityInstance.getLocalId());
+                                }
+                            });
+                        }
                     }
                 }
                 Dhis2Application.getEventBus().post(
                         new OnTeiDownloadedEvent(OnTeiDownloadedEvent.EventType.END,
                                 getSelectedTrackedEntityInstances().size()));
                 Dhis2Application.getEventBus().post(new UiEvent(UiEvent.UiEventType.SYNCING_END));
-                SynchronisationStateHandler.getInstance().changeState(false);
+                SynchronisationStateHandler.getInstance().changeState(false);activity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        if(backNavigation) {
+                            getActivity().finish();
+                            HolderActivity.mCallBack.onSuccess();
+                        }
+                    }
+                });
                 return new Object();
             }
         });

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/EnrollmentDateSetterHelper.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/EnrollmentDateSetterHelper.java
@@ -29,12 +29,12 @@
 
 package org.hisp.dhis.android.trackercapture.fragments.selectprogram;
 
-import android.app.DatePickerDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.widget.DatePicker;
 
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
+import org.hisp.dhis.android.sdk.ui.views.CustomDatePickerDialog;
 import org.hisp.dhis.android.trackercapture.R;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -93,11 +93,11 @@ public class EnrollmentDateSetterHelper {
     private void showEnrollmentDatePicker() {
         enrollmentDate = new DateTime(1, 1, 1, 1, 0);
         LocalDate currentDate = new LocalDate();
-        final DatePickerDialog enrollmentDatePickerDialog =
-                new DatePickerDialog(context,
+        final CustomDatePickerDialog enrollmentDatePickerDialog =
+                new CustomDatePickerDialog(context,
                         null, currentDate.getYear(),
                         currentDate.getMonthOfYear() - 1, currentDate.getDayOfMonth());
-        enrollmentDatePickerDialog.setTitle(context.getString(R.string.please_enter) + " " + enrollmentDateLabel);
+        enrollmentDatePickerDialog.setPermanentTitle(context.getString(R.string.please_enter) + " " + enrollmentDateLabel);
         enrollmentDatePickerDialog.setCanceledOnTouchOutside(true);
         if(!enrollmentDatesInFuture) {
             enrollmentDatePickerDialog.getDatePicker().setMaxDate(DateTime.now().getMillis());
@@ -131,11 +131,11 @@ public class EnrollmentDateSetterHelper {
     private void showIncidentDatePicker() {
         LocalDate currentDate = new LocalDate();
         incidentDate = new DateTime(1, 1, 1, 1, 0);
-        final DatePickerDialog incidentDatePickerDialog =
-                new DatePickerDialog(context,
+        final CustomDatePickerDialog incidentDatePickerDialog =
+                new CustomDatePickerDialog(context,
                         null, currentDate.getYear(),
                         currentDate.getMonthOfYear() - 1, currentDate.getDayOfMonth());
-        incidentDatePickerDialog.setTitle(context.getString(R.string.please_enter) + " " + incidentDateLabel);
+        incidentDatePickerDialog.setPermanentTitle(context.getString(R.string.please_enter) + " " + incidentDateLabel);
         incidentDatePickerDialog.setCanceledOnTouchOutside(true);
         if(!incidentDatesInFuture) {
             incidentDatePickerDialog.getDatePicker().setMaxDate(DateTime.now().getMillis());

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragment.java
@@ -246,7 +246,7 @@ public class SelectProgramFragment extends org.hisp.dhis.android.sdk.ui.fragment
     }
 
     private final void showOnlineSearchFragment(String orgUnit, String program) {
-        HolderActivity.navigateToOnlineSearchFragment(getActivity(), program, orgUnit);
+        HolderActivity.navigateToOnlineSearchFragment(getActivity(), program, orgUnit, false, null);
     }
 
     public void showStatusDialog(BaseSerializableModel model) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragment.java
@@ -145,15 +145,6 @@ public class SelectProgramFragment extends org.hisp.dhis.android.sdk.ui.fragment
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
-        inflater.inflate(R.menu.menu_select_program, menu);
-        MenuItem item = menu.findItem(R.id.action_search);
-
-        SearchView searchView = (SearchView) MenuItemCompat.getActionView(item);
-        MenuItemCompat.setOnActionExpandListener(item, this);
-
-        searchView.setOnQueryTextListener(this);
-        searchView.setOnQueryTextFocusChangeListener(this);
-        searchView.setOnCloseListener(this);
     }
 
     @Override

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragmentQuery.java
@@ -133,9 +133,9 @@ public class SelectProgramFragmentQuery implements Query<SelectProgramFragmentFo
         }
         teiRows.add(columnNames);
 
-        if(!selectedProgram.isDisplayFrontPageList()) {
-            return fragmentForm; // we don't want to show any values or any list header
-        }
+//        if(!selectedProgram.isDisplayFrontPageList()) {
+//            return fragmentForm; // we don't want to show any values or any list header
+//        }
 
         String query = getTrackedEntityInstancesWithEnrollmentQuery(mOrgUnitId, mProgramId);
         if(query == null) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragmentQuery.java
@@ -133,9 +133,9 @@ public class SelectProgramFragmentQuery implements Query<SelectProgramFragmentFo
         }
         teiRows.add(columnNames);
 
-//        if(!selectedProgram.isDisplayFrontPageList()) {
-//            return fragmentForm; // we don't want to show any values or any list header
-//        }
+        if(!selectedProgram.isDisplayFrontPageList()) {
+            return fragmentForm; // we don't want to show any values or any list header
+        }
 
         String query = getTrackedEntityInstancesWithEnrollmentQuery(mOrgUnitId, mProgramId);
         if(query == null) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/SelectProgramFragmentQuery.java
@@ -76,7 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
+public class SelectProgramFragmentQuery implements Query<SelectProgramFragmentForm> {
     private final String mOrgUnitId;
     private final String mProgramId;
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/dialogs/QueryTrackedEntityInstancesDialogFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/dialogs/QueryTrackedEntityInstancesDialogFragmentQuery.java
@@ -94,7 +94,7 @@ public class QueryTrackedEntityInstancesDialogFragmentQuery implements Query<Que
             }
             Row row = DataEntryRowFactory.createDataEntryView(ptea.getMandatory(),
                     ptea.getAllowFutureDate(), trackedEntityAttribute.getOptionSet(),
-                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false);
+                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false, program.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         form.setTrackedEntityAttributeValues(values);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/settings/SettingsFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/settings/SettingsFragment.java
@@ -1,0 +1,79 @@
+package org.hisp.dhis.android.trackercapture.fragments.settings;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.view.View;
+import android.widget.CompoundButton;
+import android.widget.Toast;
+
+import org.hisp.dhis.android.sdk.ui.views.FontButton;
+import org.hisp.dhis.android.sdk.ui.views.FontCheckBox;
+import org.hisp.dhis.android.trackercapture.R;
+import org.hisp.dhis.android.trackercapture.export.ExportData;
+
+import java.io.IOException;
+
+public class SettingsFragment extends
+        org.hisp.dhis.android.sdk.ui.fragments.settings.SettingsFragment{
+
+    private FontButton exportDataButton;
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        exportDataButton = (FontButton) view.findViewById(R.id.settings_export_data);
+        exportDataButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onExportDataClick();
+            }
+        });
+        FontCheckBox fontCheckBox = (FontCheckBox) view.findViewById(
+                R.id.checkbox_developers_options);
+
+        Context context = getActivity().getApplicationContext();
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(
+                context);
+        fontCheckBox.setChecked(sharedPreferences.getBoolean(
+                getActivity().getApplicationContext().getResources().getString(
+                        R.string.developer_option_key), false));
+        toggleOptions(fontCheckBox.isChecked());
+        fontCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean value) {
+                SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(
+                        getActivity().getApplicationContext());
+                SharedPreferences.Editor prefEditor =
+                        sharedPref.edit(); // Get preference in editor mode
+                prefEditor.putBoolean(
+                        getActivity().getApplicationContext().getResources().getString(
+                                org.hisp.dhis.android.sdk.R.string.developer_option_key), value);
+                prefEditor.commit();
+                toggleOptions(value);
+            }
+        });
+    }
+
+    private void toggleOptions(boolean value) {
+        if (value) {
+            exportDataButton.setVisibility(View.VISIBLE);
+        } else {
+            exportDataButton.setVisibility(View.INVISIBLE);
+        }
+    }
+
+    public void onExportDataClick() {
+        ExportData exportData = new ExportData();
+        Intent emailIntent = null;
+        try {
+            emailIntent = exportData.dumpAndSendToAIntent(getActivity());
+        } catch (IOException e) {
+            Toast.makeText(getContext(), org.hisp.dhis.android.sdk.R.string.error_exporting_data, Toast.LENGTH_LONG).show();
+        }
+        if (emailIntent != null) {
+            startActivity(emailIntent);
+        }
+    }
+}

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/settings/SettingsFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/settings/SettingsFragment.java
@@ -9,6 +9,10 @@ import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.Toast;
 
+import com.squareup.otto.Subscribe;
+
+import org.hisp.dhis.android.sdk.events.LoadingMessageEvent;
+import org.hisp.dhis.android.sdk.events.UiEvent;
 import org.hisp.dhis.android.sdk.ui.views.FontButton;
 import org.hisp.dhis.android.sdk.ui.views.FontCheckBox;
 import org.hisp.dhis.android.trackercapture.R;
@@ -75,5 +79,17 @@ public class SettingsFragment extends
         if (emailIntent != null) {
             startActivity(emailIntent);
         }
+    }
+
+
+    @Subscribe
+    public void onSynchronizationFinishedEvent(final UiEvent event)
+    {
+        super.onSynchronizationFinishedEvent(event);
+    }
+
+    @Subscribe
+    public void onLoadingMessageEvent(final LoadingMessageEvent event) {
+        super.onLoadingMessageEvent(event);
     }
 }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragmentQuery.java
@@ -108,7 +108,7 @@ public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedE
             Row row = DataEntryRowFactory.createDataEntryView(programTrackedEntityAttributes.get(i).getMandatory(),
                     programTrackedEntityAttributes.get(i).getAllowFutureDate(), programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getOptionSet(),
                     programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getName(), getTrackedEntityDataValue(programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getUid(),
-                            trackedEntityAttributeValues), programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getValueType(), false, shouldNeverBeEdited);
+                            trackedEntityAttributeValues), programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getValueType(), false, shouldNeverBeEdited, mProgram.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         if (trackedEntityAttributeValues != null) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/upcomingevents/UpcomingEventsFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/upcomingevents/UpcomingEventsFragmentQuery.java
@@ -89,7 +89,11 @@ class UpcomingEventsFragmentQuery implements Query<SelectProgramFragmentForm> {
 
         List<String> attributesToShow = new ArrayList<>();
         UpcomingEventsColumnNamesRow columnNames = new UpcomingEventsColumnNamesRow();
-        columnNames.setTitle(mFilterLabel + " " + "EVENTS");
+        String title = "EVENTS";
+        if(mFilterLabel!=null){
+            title = mFilterLabel + " " + title;
+        }
+        columnNames.setTitle(title);
         for (ProgramTrackedEntityAttribute attribute : programTrackedEntityAttributes) {
             if (attribute.getDisplayInList() && attributesToShow.size() < mNumAttributesToShow) {
                 attributesToShow.add(attribute.getTrackedEntityAttributeId());

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/ui/rows/programoverview/ProgramStageLabelRow.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/ui/rows/programoverview/ProgramStageLabelRow.java
@@ -84,6 +84,7 @@ public class ProgramStageLabelRow implements ProgramStageRow {
             holder.newEventButton.setOnClickListener(listener);
             holder.newEventButton.setVisibility(View.VISIBLE);
             holder.newEventButton.setEnabled(true);
+            holder.newEventButton.setTag(programStage);
         }
         else
         {

--- a/app/src/main/res/layout/dialog_fragment_registerrelationship.xml
+++ b/app/src/main/res/layout/dialog_fragment_registerrelationship.xml
@@ -94,12 +94,11 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="4dp"
         app:hint="@string/select_relationship_type" />
-    
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
-
         <org.hisp.dhis.android.sdk.ui.views.FontTextView
             android:id="@+id/tei_label"
             android:layout_width="wrap_content"
@@ -132,39 +131,57 @@
             android:gravity="center_vertical"
             android:id="@+id/spinner"
             android:layout_gravity="right|center_horizontal" />
+    </LinearLayout>
 
 
-        </LinearLayout>
-
-
-    <org.hisp.dhis.android.sdk.ui.views.FontEditText
-        android:id="@+id/filter_options"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="48dp"
-        android:layout_margin="16dp"
-        android:drawableRight ="@drawable/ic_search"
-        android:singleLine="true"
-        android:drawablePadding="4dp"
-        android:imeOptions="actionSearch"
-        android:inputType="text"
-        android:hint="@string/search"
-        app:font="@string/light_font_name"/>
-
-    <ProgressBar
-        android:id="@+id/progress_bar"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="28dp"
-        android:layout_gravity="center_horizontal"
-        android:indeterminate="true" />
+        android:orientation="vertical">
 
-    <ListView
-        android:id="@+id/simple_listview"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:cacheColorHint="@color/transparent"
-        android:divider="@color/darker_grey"
-        android:dividerHeight="1px"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+            <org.hisp.dhis.android.sdk.ui.views.FontEditText
+                android:id="@+id/filter_options"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="0.8"
+                android:layout_margin="16dp"
+                android:drawableRight ="@drawable/ic_search"
+                android:singleLine="true"
+                android:drawablePadding="4dp"
+                android:imeOptions="actionSearch"
+                android:inputType="text"
+                android:hint="@string/search"
+                app:font="@string/light_font_name"/>
+        <org.hisp.dhis.android.sdk.ui.views.FloatingActionButton
+            android:id="@+id/search_and_download_button"
+            android:layout_height="48dp"
+            android:layout_width="0dp"
+            android:layout_weight="0.15"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_search_server" />
+        </LinearLayout>
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="28dp"
+            android:layout_gravity="center_horizontal"
+            android:indeterminate="true" />
+
+        <ListView
+            android:id="@+id/simple_listview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:cacheColorHint="@color/transparent"
+            android:divider="@color/darker_grey"
+            android:dividerHeight="1px"/>
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_fragment_selection_program.xml
+++ b/app/src/main/res/layout/dialog_fragment_selection_program.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ * Copyright (c) 2016, University of Oslo
+  ~  * All rights reserved.
+  ~  *
+  ~  * Redistribution and use in source and binary forms, with or without
+  ~  * modification, are permitted provided that the following conditions are met:
+  ~  * Redistributions of source code must retain the above copyright notice, this
+  ~  * list of conditions and the following disclaimer.
+  ~  *
+  ~  * Redistributions in binary form must reproduce the above copyright notice,
+  ~  * this list of conditions and the following disclaimer in the documentation
+  ~  * and/or other materials provided with the distribution.
+  ~  * Neither the name of the HISP project nor the names of its contributors may
+  ~  * be used to endorse or promote products derived from this software without
+  ~  * specific prior written permission.
+  ~  *
+  ~  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+  ~  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ~  */
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:minHeight="520dp"
+    android:minWidth="320dp">
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:background="@color/navy_blue"
+        android:orientation="horizontal"
+        android:weightSum="1">
+
+        <org.hisp.dhis.android.sdk.ui.views.FontTextView
+            android:id="@+id/dialog_label"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:gravity="center_vertical"
+            android:padding="16dp"
+            android:singleLine="true"
+            android:textAllCaps="true"
+            android:textColor="@color/white"
+            android:textSize="19sp"
+            app:font="@string/condensed_font_name"/>
+
+
+        <ImageView
+            android:id="@+id/close_dialog_button"
+            android:layout_width="56dp"
+            android:layout_height="56dp"
+            android:adjustViewBounds="true"
+            android:background="@drawable/transparent_selector"
+            android:clickable="true"
+            android:contentDescription="@string/description"
+            android:padding="8dp"
+            android:src="@drawable/ic_close_dialog"/>
+
+    </LinearLayout>
+
+    <org.hisp.dhis.android.sdk.ui.views.CardTextViewButton
+        android:id="@+id/select_organisation_unit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="6dp"
+        app:hint="@string/choose_organisation_unit" />
+
+    <org.hisp.dhis.android.sdk.ui.views.CardTextViewButton
+        android:id="@+id/select_program"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
+        app:hint="@string/choose_program" />
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_gravity="center"
+        android:gravity="center">
+
+        <org.hisp.dhis.android.sdk.ui.views.FloatingActionButton
+            android:id="@+id/search_and_download_button"
+            android:layout_height="48dp"
+            android:layout_width="48dp"
+            android:layout_weight="0.15"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:scaleType="centerInside"
+            android:layout_gravity="center"
+            android:src="@drawable/ic_search_server" />
+
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_fragment_selection_program.xml
+++ b/app/src/main/res/layout/dialog_fragment_selection_program.xml
@@ -32,7 +32,6 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:minHeight="520dp"
     android:minWidth="320dp">
 
 

--- a/app/src/main/res/layout/fragment_programoverview_header.xml
+++ b/app/src/main/res/layout/fragment_programoverview_header.xml
@@ -56,6 +56,7 @@
             android:visibility="gone">
 
             <TextView
+                android:id="@+id/noactiveenrollment"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"

--- a/app/src/main/res/layout/fragment_programoverview_header.xml
+++ b/app/src/main/res/layout/fragment_programoverview_header.xml
@@ -319,6 +319,14 @@
                     android:textSize="@dimen/medium_text_size" />
 
                 <Button
+                    android:id="@+id/pullrelationshipbutton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="30dp"
+                    android:layout_gravity="right"
+                    android:background="@drawable/transparent_selector"
+                    android:text="@string/refresh_string" />
+
+                <Button
                     android:id="@+id/addrelationshipbutton"
                     android:layout_width="wrap_content"
                     android:layout_height="30dp"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ * Copyright (c) 2016, University of Oslo
+  ~  * All rights reserved.
+  ~  *
+  ~  * Redistribution and use in source and binary forms, with or without
+  ~  * modification, are permitted provided that the following conditions are met:
+  ~  * Redistributions of source code must retain the above copyright notice, this
+  ~  * list of conditions and the following disclaimer.
+  ~  *
+  ~  * Redistributions in binary form must reproduce the above copyright notice,
+  ~  * this list of conditions and the following disclaimer in the documentation
+  ~  * and/or other materials provided with the distribution.
+  ~  * Neither the name of the HISP project nor the names of its contributors may
+  ~  * be used to endorse or promote products derived from this software without
+  ~  * specific prior written permission.
+  ~  *
+  ~  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+  ~  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ~  */
+  -->
+
+<resources>
+
+    <string name="action_settings">Configuración</string>
+    <string name="register_new_event">Registrar nuevo evento</string>
+    <string name="registered_events">Eventos registrados</string>
+    <string name="register_relationship">Registrar una relación</string>
+    <string name="new_event">Nuevo evento</string>
+    <string name="enroll">Registrar</string>
+
+    <string name="is">es</string>
+    <string name="please_enter">Por favor introduce</string>
+
+    <string name="report_date">Fecha de informe</string>
+    <string name="event_sent">Enviado</string>
+    <string name="event_offline">Sin conexión</string>
+    <string name="event_error">Error</string>
+
+    <string name="error_401_description">El usuario o la contraseña han cambiado. Por favor desconecta y vuelve a conectar. \nNota! El evento se perderá</string>
+    <string name="error_408_description">Conexión lenta. Por favor intenta sincronizar más tarde</string>
+    <string name="error_series_400_description">Error de aplicación 40x</string>
+    <string name="error_series_500_description">Error de servidor 50x. Por favor, intenta sincronizar más tarde.</string>
+    <string name="unknown_error">Error desconocido</string>
+
+    <string name="confirm_complete_enrollment">¿Estás seguro de querer completar el registro\n        actual? No se podrá editar posteriormente</string>
+    <string name="confirm_terminate_enrollment">¿Estás seguro de querer cancelar el registro\n        actual? No se podrá deshacer esta acción.</string>
+    <string name="confirm_delete_relationship">¿Estás seguro de querer borrar esta relación?</string>
+    <string name="no_active_enrollment">No existe registro activo</string>
+    <string name="select_relationship_type">Seleccione el tipo de relación</string>
+
+    <string name="search">Buscar</string>
+    <string name="http_error_400">Petición incorrecta</string>
+    <string name="http_error_401">No autorizado</string>
+    <string name="http_error_403">Prohibido</string>
+    <string name="http_error_409">Conflicto</string>
+    <string name="http_error_500">Error interno de servidor</string>
+    <string name="http_error_501">No implementado</string>
+    <string name="http_error_502">Pasarela inválida</string>
+    <string name="http_error_503">Servicio no disponible</string>
+    <string name="http_error_504">Conexión con pasarela expirada</string>
+
+    <string name="search_results">Resultados de la búsqueda</string>
+    <string name="search_online">¿No encuentras lo que estabas buscando? Búqueda en línea</string>
+    <string name="local_search">Búsqueda local</string>
+
+    <string name="out_of_generated_ids">Se te han acabado los IDs generados automáticamente. Por favor sincroniza para descargar más</string>
+    <string name="generic_error">Error. Por favor intenta de nuevo</string>
+    <string name="re_open">Reabrir</string>
+
+    <string name="download_entities_title">Descargar entidades</string>
+    <string name="enrollemnt_complete">Registro completo</string>
+
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ * Copyright (c) 2016, University of Oslo
+  ~  * All rights reserved.
+  ~  *
+  ~  * Redistribution and use in source and binary forms, with or without
+  ~  * modification, are permitted provided that the following conditions are met:
+  ~  * Redistributions of source code must retain the above copyright notice, this
+  ~  * list of conditions and the following disclaimer.
+  ~  *
+  ~  * Redistributions in binary form must reproduce the above copyright notice,
+  ~  * this list of conditions and the following disclaimer in the documentation
+  ~  * and/or other materials provided with the distribution.
+  ~  * Neither the name of the HISP project nor the names of its contributors may
+  ~  * be used to endorse or promote products derived from this software without
+  ~  * specific prior written permission.
+  ~  *
+  ~  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+  ~  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ~  */
+  -->
+
+<resources>
+
+    <string name="action_settings">Paramètres</string>
+    <string name="register_new_event">Enregistrer un nouvel événement</string>
+    <string name="registered_events">Événements enregistrés</string>
+    <string name="register_relationship">Enregistrer une rélation</string>
+    <string name="new_event">Nouvel événement</string>
+    <string name="enroll">Enregistrer</string>
+
+    <string name="is">est</string>
+    <string name="please_enter">Prière d\'introduir</string>
+
+    <string name="report_date">Date du rapport</string>
+    <string name="event_sent">Envoyé</string>
+    <string name="event_offline">Hors ligne</string>
+    <string name="event_error">Erreur</string>
+
+    <string name="error_401_description">Identifiant ou mot de passe modifiés. Prière de se déconnecter et se reconnecter. \nNote! L\'évènement sera perdu</string>
+    <string name="error_408_description">Connection faible. Prière de synchroniser plus tard</string>
+    <string name="error_series_400_description">Erreur d\'application 40x</string>
+    <string name="error_series_500_description">Erreur de serveur 50x. Prière de synchroniser plus tard.</string>
+    <string name="unknown_error">Erreur inconnue</string>
+
+    <string name="confirm_complete_enrollment">Souhaitez-vous vraiment compléter l\'enregistrement?\n        Vous ne pourrez plus éditer ultérierement</string>
+    <string name="confirm_terminate_enrollment">Souhaitez-vous vraiment annuler cette\n        enregistrement ? Vous ne pourrez plus revenir en arrière.</string>
+    <string name="confirm_delete_relationship">Souhaitez-vous vraiment supprimer cette relation ?</string>
+    <string name="no_active_enrollment">Pas d\'enregistrement actif</string>
+    <string name="select_relationship_type">Sélectionnez le type de rélation</string>
+
+    <string name="search">Rechercher</string>
+    <string name="http_error_400">Requête incorrecte</string>
+    <string name="http_error_401">Non autorisé</string>
+    <string name="http_error_403">Interdit</string>
+    <string name="http_error_409">Conflit</string>
+    <string name="http_error_500">Erreur interne du serveur</string>
+    <string name="http_error_501">Non développé</string>
+    <string name="http_error_502">Passerelle invalide</string>
+    <string name="http_error_503">Service indisponible</string>
+    <string name="http_error_504">Connection à la passerelle expirée</string>
+
+    <string name="search_results">Résultats de votre recherche</string>
+    <string name="search_online">Vous ne trouvez pas ce que vous recherchez ? Recherche en ligne</string>
+    <string name="local_search">Recherche locale</string>
+
+    <string name="out_of_generated_ids">Il n\'y a plus d\'identifiants automatiquement générés. Prière de synchroniser pour en télecharger de nouveaux</string>
+    <string name="generic_error">Erreur. Prière de réessayer</string>
+    <string name="re_open">Rouvrir</string>
+
+    <string name="download_entities_title">Télécharger entités</string>
+    <string name="enrollemnt_complete">Enregistrement complété</string>
+
+</resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ * Copyright (c) 2017, University of Oslo
+  ~  * All rights reserved.
+  ~  *
+  ~  * Redistribution and use in source and binary forms, with or without
+  ~  * modification, are permitted provided that the following conditions are met:
+  ~  * Redistributions of source code must retain the above copyright notice, this
+  ~  * list of conditions and the following disclaimer.
+  ~  *
+  ~  * Redistributions in binary form must reproduce the above copyright notice,
+  ~  * this list of conditions and the following disclaimer in the documentation
+  ~  * and/or other materials provided with the distribution.
+  ~  * Neither the name of the HISP project nor the names of its contributors may
+  ~  * be used to endorse or promote products derived from this software without
+  ~  * specific prior written permission.
+  ~  *
+  ~  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+  ~  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ~  */
+  -->
+<resources>
+    <string name="app_name" translatable="false">DHIS 2 Tracker Capture</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,5 +82,6 @@
 
     <string name="online_query_tracked_entity_instances">Online query tracked entity instances</string>
     <string name="download_entities_title">Download entities from server</string>
+    <string name="enrollemnt_complete">Enrollment is complete</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,8 +80,7 @@
     <string name="generic_error">Error. Please retry</string>
     <string name="re_open">Re-open</string>
 
-    <string name="online_query_tracked_entity_instances">Online query tracked entity instances</string>
-    <string name="download_entities_title">Download entities from server</string>
+    <string name="download_entities_title">Download entities</string>
     <string name="enrollemnt_complete">Enrollment is complete</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,8 +30,6 @@
 
 <resources>
 
-    <string name="app_name">DHIS 2 Tracker Capture</string>
-    <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
     <string name="register_new_event">Register new event</string>
     <string name="registered_events">Registered events</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,5 +81,6 @@
     <string name="re_open">Re-open</string>
 
     <string name="online_query_tracked_entity_instances">Online query tracked entity instances</string>
+    <string name="download_entities_title">Download entities from server</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,5 +80,6 @@
     <string name="generic_error">Error. Please retry</string>
     <string name="re_open">Re-open</string>
 
+    <string name="online_query_tracked_entity_instances">Online query tracked entity instances</string>
 
 </resources>

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Definitions
+gitPath=$(git rev-parse --show-toplevel)
+
+# Generate last commit
+sh ${gitPath}/generate_last_commit.sh

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -5,3 +5,8 @@ gitPath=$(git rev-parse --show-toplevel)
 
 # Generate last commit
 sh ${gitPath}/generate_last_commit.sh
+
+# Use tracker capture SDK branch
+cd sdk
+git checkout tracker-capture
+cd -

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ ext {
     versionName = "0.3.37-2.26"
 
     configuration = [
+            package          : "org.hisp.dhis.android.trackercapture",
             buildToolsVersion: "23.0.2",
             minSdkVersion    : 15,
             compileSdkVersion: 23,

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ ext {
             minSdkVersion    : 15,
             compileSdkVersion: 23,
             targetSdkVersion : 23,
-            versionCode      : 54,
-            versionName      : "0.3.37-2.26"
+            versionCode      : 55,
+            versionName      : "0.3.38"
     ]
 
     libraries = [

--- a/generate_last_commit.sh
+++ b/generate_last_commit.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+gitPath=$(git rev-parse --show-toplevel)
+filePath="${gitPath}/app/src/main/res/raw/lastcommit.txt"
+echo "Last commit path $filePath"
+commit=$(git log -1 HEAD --format=%H)
+echo "Saving last commit: ${commit}"
+echo ${commit} > $filePath
+echo "Done."

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 include ':app', ':core', ':ui', ':utils'
-project(':core').projectDir = new File(settingsDir, '../dhis2-android-sdk/core')
-project(':ui').projectDir = new File(settingsDir, '../dhis2-android-sdk/ui')
-project(':utils').projectDir = new File(settingsDir, '../dhis2-android-sdk/utils')
+project(':core').projectDir = new File(settingsDir, 'sdk/core')
+project(':ui').projectDir = new File(settingsDir, 'sdk/ui')
+project(':utils').projectDir = new File(settingsDir, 'sdk/utils')


### PR DESCRIPTION
This PR solves the following issues:
New features:
- Integrate sdk as a git submodule
- Integrate buddybuild
- Add about us with information about the app, version and last commit hash
- Add developers options in settings with export DB option to send DB to developers
- Add Spanish and French translations
- Add button to synchronize remotely deleted events, tracked entities, enrollments, etc
- Show "value-type not supported" for not supported value types instead of long text
- Order TE attributes based like web side and use only display in list TEA to show relationships info
- Make local search work like online search, applying no filter when nothing is selected
- Show correct screen titles when navigating to different seach criteria screens
- Make logout take the user to the login screen
- Create a shortcut to entities downloader from entity relationship creation screen (https://jira.dhis2.org/browse/ACA-45)
- Make show optionsets as dropdown/radiobuttons setting for programs propagate to Android (https://jira.dhis2.org/browse/ACA-34)
- Add support for percentage value types (https://jira.dhis2.org/browse/ACA-26)
- Add support for age value types (https://jira.dhis2.org/browse/ACA-25)
- Cosmetic changes

Bugfixing:
- ViewHolder pattern wrongly used in the app with consequences in some of the following issues
- Program stage selection failing on multiple stages with sections (https://jira.dhis2.org/browse/ACA-39)
- Erratic yes/no selection (https://jira.dhis2.org/browse/ACA-37)
- TC: Event added for wrong program stage (https://jira.dhis2.org/browse/ACA-35)
- Remove unused search fields on dashboard
- Upcoming events filter show null when no filter is applied
- Refactor enrollment selection code, and make it work
- Make re-open enrollment button work
- Show incident date and report date titles on calendar picker
- Never ending sync bug after enrollment creation
- Reinitialize session after a crash

