### PR TITLE
2.23 legacy

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
+apply plugin: 'jacoco-android'
 
 android {
 //    compileSdkVersion rootProject.ext.configuration.compileSdkVersion
@@ -57,10 +58,14 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            testCoverageEnabled true
+        }
     }
 
     lintOptions {
         disable 'RtlSymmetry', 'RtlHardcoded'
+        abortOnError false
     }
 
     packagingOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="org.hisp.dhis.android.trackercapture">
 
     <uses-sdk android:targetSdkVersion="21" />
@@ -41,7 +42,8 @@
 
     <application
         android:name="org.hisp.dhis.android.trackercapture.TrackerCaptureApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        tools:replace="android:allowBackup"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme.Base">

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/MainActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/MainActivity.java
@@ -31,10 +31,14 @@ package org.hisp.dhis.android.trackercapture;
 
 import static org.hisp.dhis.client.sdk.utils.StringUtils.isEmpty;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.view.MenuItem;
 import android.view.View;
 
@@ -66,10 +70,19 @@ public class MainActivity extends AbsHomeActivity {
             "org.hisp.dhis.android.trackercapture";
     private static final String APPS_TRACKER_CAPTURE_REPORTS_PACKAGE =
             "org.hispindia.bidtrackerreports";
+    private static final int REQUEST_ACCESS_FINE_LOCATION = 1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        boolean hasPermissionLocation = (ContextCompat.checkSelfPermission(MainActivity.this,
+                Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED);
+        if (!hasPermissionLocation) {
+            ActivityCompat.requestPermissions(MainActivity.this,
+                    new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
+                    REQUEST_ACCESS_FINE_LOCATION);
+        }
 
         if ((getIntent().getFlags() & Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {
             // Activity was brought to front and not created,

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
@@ -53,7 +53,11 @@ public class HolderActivity extends AbsHomeActivity {
     @Override
     public void onBackPressed() {
         if (onBackPressedListener != null) {
-            if (onBackPressedListener.doBack()) {
+            if (onBackPressedListener instanceof  EventDataEntryFragment) {
+                if(((EventDataEntryFragment) onBackPressedListener).onBackPressed()){
+                    super.onBackPressed();
+                }
+            }else if (onBackPressedListener.doBack()) {
                 super.onBackPressed();
             }
         } else {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/activities/HolderActivity.java
@@ -53,11 +53,7 @@ public class HolderActivity extends AbsHomeActivity {
     @Override
     public void onBackPressed() {
         if (onBackPressedListener != null) {
-            if (onBackPressedListener instanceof  EventDataEntryFragment) {
-                if(((EventDataEntryFragment) onBackPressedListener).onBackPressed()){
-                    super.onBackPressed();
-                }
-            }else if (onBackPressedListener.doBack()) {
+            if (onBackPressedListener.doBack()) {
                 super.onBackPressed();
             }
         } else {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragment.java
@@ -57,7 +57,6 @@ import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.activities.OnBackPressedListener;
 import org.hisp.dhis.android.sdk.ui.adapters.SectionAdapter;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RunProgramRulesEvent;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.events.OnDetailedInfoButtonClick;
@@ -383,7 +382,7 @@ public class EnrollmentDataEntryFragment extends DataEntryFragment<EnrollmentDat
         super.onRowValueChanged(event);
 
         // do not run program rules for EditTextRows - DelayedDispatcher takes care of this
-        if (event.getRow() == null || !(event.getRow() instanceof EditTextRow)) {
+        if (event.getRow() == null || !(event.getRow().isEditTextRow())) {
             evaluateRules(event.getId());
         }
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragment.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.activities.OnBackPressedListener;
 import org.hisp.dhis.android.sdk.ui.adapters.SectionAdapter;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RunProgramRulesEvent;
@@ -336,10 +337,15 @@ public class EnrollmentDataEntryFragment extends DataEntryFragment<EnrollmentDat
         ArrayList<String> programRulesValidationErrors =
                 getProgramRuleFragmentHelper().getProgramRuleValidationErrors();
         ArrayList<String> mandatoryValidationErrors = getValidationErrors();
-        if (programRulesValidationErrors.isEmpty() && mandatoryValidationErrors.isEmpty()) {
+        ArrayList<String> validationErrors = new ArrayList<>();
+        for(DataEntryRow dataEntryRow : form.getDataEntryRows()){
+            if(dataEntryRow.getValidationError()!=null)
+                validationErrors.add(getContext().getString(dataEntryRow.getValidationError()));
+        }
+        if (programRulesValidationErrors.isEmpty() && mandatoryValidationErrors.isEmpty() && validationErrors.isEmpty()) {
             return true;
         } else {
-            showValidationErrorDialog(mandatoryValidationErrors, programRulesValidationErrors);
+            showValidationErrorDialog(mandatoryValidationErrors, programRulesValidationErrors, validationErrors);
             return false;
         }
     }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragment.java
@@ -29,6 +29,8 @@
 
 package org.hisp.dhis.android.trackercapture.fragments.enrollment;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.content.Loader;
@@ -71,8 +73,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class EnrollmentDataEntryFragment extends DataEntryFragment<EnrollmentDataEntryFragmentForm>
         implements OnBackPressedListener {
@@ -329,7 +329,13 @@ public class EnrollmentDataEntryFragment extends DataEntryFragment<EnrollmentDat
     }
 
     private boolean validate() {
-        ArrayList<String> programRulesValidationErrors = getProgramRuleFragmentHelper().getProgramRuleValidationErrors();
+        if (isMapEmpty(form.getTrackedEntityAttributeValueMap())) {
+            UiUtils.showErrorDialog(getActivity(), getContext().getString(org.hisp.dhis.android.trackercapture.R.string.error_message),
+                    getContext().getString(org.hisp.dhis.android.trackercapture.R.string.profile_form_empty));
+            return false;
+        }
+        ArrayList<String> programRulesValidationErrors =
+                getProgramRuleFragmentHelper().getProgramRuleValidationErrors();
         ArrayList<String> mandatoryValidationErrors = getValidationErrors();
         if (programRulesValidationErrors.isEmpty() && mandatoryValidationErrors.isEmpty()) {
             return true;
@@ -337,6 +343,18 @@ public class EnrollmentDataEntryFragment extends DataEntryFragment<EnrollmentDat
             showValidationErrorDialog(mandatoryValidationErrors, programRulesValidationErrors);
             return false;
         }
+    }
+
+    private boolean isMapEmpty(
+            Map<String, TrackedEntityAttributeValue> trackedEntityAttributeValueMap) {
+        boolean isEmpty = true;
+        for (String key : trackedEntityAttributeValueMap.keySet()) {
+            TrackedEntityAttributeValue value = trackedEntityAttributeValueMap.get(key);
+            if (value.getValue() != null && !value.getValue().equals("")) {
+                isEmpty = false;
+            }
+        }
+        return isEmpty;
     }
 
     private void evaluateRules(String trackedEntityAttribute) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/enrollment/EnrollmentDataEntryFragmentQuery.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
 import org.hisp.dhis.android.sdk.persistence.models.Enrollment;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.OrganisationUnit;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramTrackedEntityAttribute;
@@ -45,14 +44,8 @@ import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeGenera
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowFactory;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.autocompleterow.AutoCompleteRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CheckBoxRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DatePickerRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EnrollmentDatePickerRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.IncidentDatePickerRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RadioButtonsRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.utils.api.ValueType;
 
@@ -72,8 +65,8 @@ class EnrollmentDataEntryFragmentQuery implements Query<EnrollmentDataEntryFragm
     private Enrollment currentEnrollment;
 
     EnrollmentDataEntryFragmentQuery(String mOrgUnitId, String mProgramId,
-                                     long mTrackedEntityInstanceId,
-                                     String enrollmentDate, String incidentDate) {
+            long mTrackedEntityInstanceId,
+            String enrollmentDate, String incidentDate) {
         this.mOrgUnitId = mOrgUnitId;
         this.mProgramId = mProgramId;
         this.mTrackedEntityInstanceId = mTrackedEntityInstanceId;
@@ -94,12 +87,15 @@ class EnrollmentDataEntryFragmentQuery implements Query<EnrollmentDataEntryFragm
         if (mTrackedEntityInstanceId < 0) {
             currentTrackedEntityInstance = new TrackedEntityInstance(mProgram, mOrgUnitId);
         } else {
-            currentTrackedEntityInstance = TrackerController.getTrackedEntityInstance(mTrackedEntityInstanceId);
+            currentTrackedEntityInstance = TrackerController.getTrackedEntityInstance(
+                    mTrackedEntityInstanceId);
         }
         if ("".equals(incidentDate)) {
             incidentDate = null;
         }
-        currentEnrollment = new Enrollment(mOrgUnitId, currentTrackedEntityInstance.getTrackedEntityInstance(), mProgram, enrollmentDate, incidentDate);
+        currentEnrollment = new Enrollment(mOrgUnitId,
+                currentTrackedEntityInstance.getTrackedEntityInstance(), mProgram, enrollmentDate,
+                incidentDate);
 
         mForm.setProgram(mProgram);
         mForm.setOrganisationUnit(mOrgUnit);
@@ -109,30 +105,43 @@ class EnrollmentDataEntryFragmentQuery implements Query<EnrollmentDataEntryFragm
         mForm.setTrackedEntityAttributeValueMap(new HashMap<String, TrackedEntityAttributeValue>());
 
         List<TrackedEntityAttributeValue> trackedEntityAttributeValues = new ArrayList<>();
-        List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes = mProgram.getProgramTrackedEntityAttributes();
+        List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes =
+                mProgram.getProgramTrackedEntityAttributes();
         List<Row> dataEntryRows = new ArrayList<>();
 
-        dataEntryRows.add(new EnrollmentDatePickerRow(currentEnrollment.getProgram().getEnrollmentDateLabel(), currentEnrollment));
+        dataEntryRows.add(
+                new EnrollmentDatePickerRow(currentEnrollment.getProgram().getEnrollmentDateLabel(),
+                        currentEnrollment));
 
         if (currentEnrollment.getProgram().getDisplayIncidentDate()) {
-            dataEntryRows.add(new IncidentDatePickerRow(currentEnrollment.getProgram().getIncidentDateLabel(), currentEnrollment));
+            dataEntryRows.add(
+                    new IncidentDatePickerRow(currentEnrollment.getProgram().getIncidentDateLabel(),
+                            currentEnrollment));
         }
 
         for (ProgramTrackedEntityAttribute ptea : programTrackedEntityAttributes) {
-            TrackedEntityAttributeValue value = TrackerController.getTrackedEntityAttributeValue(ptea.getTrackedEntityAttributeId(), currentTrackedEntityInstance.getLocalId());
+            TrackedEntityAttributeValue value = TrackerController.getTrackedEntityAttributeValue(
+                    ptea.getTrackedEntityAttributeId(), currentTrackedEntityInstance.getLocalId());
             if (value != null) {
                 trackedEntityAttributeValues.add(value);
             } else {
-                TrackedEntityAttribute trackedEntityAttribute = MetaDataController.getTrackedEntityAttribute(ptea.getTrackedEntityAttributeId());
+                TrackedEntityAttribute trackedEntityAttribute =
+                        MetaDataController.getTrackedEntityAttribute(
+                                ptea.getTrackedEntityAttributeId());
                 if (trackedEntityAttribute.isGenerated()) {
                     TrackedEntityAttributeGeneratedValue trackedEntityAttributeGeneratedValue =
-                            MetaDataController.getTrackedEntityAttributeGeneratedValue(ptea.getTrackedEntityAttribute());
+                            MetaDataController.getTrackedEntityAttributeGeneratedValue(
+                                    ptea.getTrackedEntityAttribute());
 
                     if (trackedEntityAttributeGeneratedValue != null) {
-                        TrackedEntityAttributeValue trackedEntityAttributeValue = new TrackedEntityAttributeValue();
-                        trackedEntityAttributeValue.setTrackedEntityAttributeId(ptea.getTrackedEntityAttribute().getUid());
-                        trackedEntityAttributeValue.setTrackedEntityInstanceId(currentTrackedEntityInstance.getUid());
-                        trackedEntityAttributeValue.setValue(trackedEntityAttributeGeneratedValue.getValue());
+                        TrackedEntityAttributeValue trackedEntityAttributeValue =
+                                new TrackedEntityAttributeValue();
+                        trackedEntityAttributeValue.setTrackedEntityAttributeId(
+                                ptea.getTrackedEntityAttribute().getUid());
+                        trackedEntityAttributeValue.setTrackedEntityInstanceId(
+                                currentTrackedEntityInstance.getUid());
+                        trackedEntityAttributeValue.setValue(
+                                trackedEntityAttributeGeneratedValue.getValue());
                         trackedEntityAttributeValues.add(trackedEntityAttributeValue);
                     } else {
                         mForm.setOutOfTrackedEntityAttributeGeneratedValues(true);
@@ -144,40 +153,53 @@ class EnrollmentDataEntryFragmentQuery implements Query<EnrollmentDataEntryFragm
         for (int i = 0; i < programTrackedEntityAttributes.size(); i++) {
             boolean editable = true;
             boolean shouldNeverBeEdited = false;
-            if(programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().isGenerated()) {
+            if (programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().isGenerated()) {
                 editable = false;
                 shouldNeverBeEdited = true;
             }
-            if(ValueType.COORDINATE.equals(programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getValueType())) {
+            if (ValueType.COORDINATE.equals(programTrackedEntityAttributes.get(
+                    i).getTrackedEntityAttribute().getValueType())) {
                 GpsController.activateGps(context);
             }
-            Row row = DataEntryRowFactory.createDataEntryView(programTrackedEntityAttributes.get(i).getMandatory(),
-                    programTrackedEntityAttributes.get(i).getAllowFutureDate(), programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getOptionSet(),
+            Row row = DataEntryRowFactory.createDataEntryView(
+                    programTrackedEntityAttributes.get(i).getMandatory(),
+                    programTrackedEntityAttributes.get(i).getAllowFutureDate(),
+                    programTrackedEntityAttributes.get(
+                            i).getTrackedEntityAttribute().getOptionSet(),
                     programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getName(),
                     getTrackedEntityDataValue(programTrackedEntityAttributes.get(i).
                             getTrackedEntityAttribute().getUid(), trackedEntityAttributeValues),
-                    programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getValueType(),
+                    programTrackedEntityAttributes.get(
+                            i).getTrackedEntityAttribute().getValueType(),
                     editable, shouldNeverBeEdited, mProgram.getDataEntryMethod());
             dataEntryRows.add(row);
         }
-        for (TrackedEntityAttributeValue trackedEntityAttributeValue : trackedEntityAttributeValues) {
-            mForm.getTrackedEntityAttributeValueMap().put(trackedEntityAttributeValue.getTrackedEntityAttributeId(), trackedEntityAttributeValue);
+        for (TrackedEntityAttributeValue trackedEntityAttributeValue :
+                trackedEntityAttributeValues) {
+            mForm.getTrackedEntityAttributeValueMap().put(
+                    trackedEntityAttributeValue.getTrackedEntityAttributeId(),
+                    trackedEntityAttributeValue);
         }
         mForm.setDataEntryRows(dataEntryRows);
         mForm.setEnrollment(currentEnrollment);
         return mForm;
     }
 
-    public TrackedEntityAttributeValue getTrackedEntityDataValue(String trackedEntityAttribute, List<TrackedEntityAttributeValue> trackedEntityAttributeValues) {
-        for (TrackedEntityAttributeValue trackedEntityAttributeValue : trackedEntityAttributeValues) {
-            if (trackedEntityAttributeValue.getTrackedEntityAttributeId().equals(trackedEntityAttribute))
+    public TrackedEntityAttributeValue getTrackedEntityDataValue(String trackedEntityAttribute,
+            List<TrackedEntityAttributeValue> trackedEntityAttributeValues) {
+        for (TrackedEntityAttributeValue trackedEntityAttributeValue :
+                trackedEntityAttributeValues) {
+            if (trackedEntityAttributeValue.getTrackedEntityAttributeId().equals(
+                    trackedEntityAttribute)) {
                 return trackedEntityAttributeValue;
+            }
         }
 
         //the datavalue didnt exist for some reason. Create a new one.
         TrackedEntityAttributeValue trackedEntityAttributeValue = new TrackedEntityAttributeValue();
         trackedEntityAttributeValue.setTrackedEntityAttributeId(trackedEntityAttribute);
-        trackedEntityAttributeValue.setTrackedEntityInstanceId(currentTrackedEntityInstance.getTrackedEntityInstance());
+        trackedEntityAttributeValue.setTrackedEntityInstanceId(
+                currentTrackedEntityInstance.getTrackedEntityInstance());
         trackedEntityAttributeValue.setValue("");
         trackedEntityAttributeValues.add(trackedEntityAttributeValue);
         return trackedEntityAttributeValue;

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -87,6 +87,7 @@ import org.hisp.dhis.android.sdk.persistence.preferences.ResourceType;
 import org.hisp.dhis.android.sdk.ui.activities.OnBackPressedListener;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.IndicatorRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.PlainTextRow;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.events.OnDetailedInfoButtonClick;
 import org.hisp.dhis.android.sdk.ui.dialogs.ProgramDialogFragment;
 import org.hisp.dhis.android.sdk.ui.fragments.common.AbsProgramRuleFragment;
 import org.hisp.dhis.android.sdk.ui.views.FloatingActionButton;
@@ -1246,5 +1247,21 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
     public boolean doBack() {
         getActivity().finish();
         return false;
+    }
+
+
+    @Subscribe
+    public void onShowDetailedInfo(OnDetailedInfoButtonClick eventClick)
+    {
+        UiUtils.showConfirmDialog(getActivity(),
+                getResources().getString(org.hisp.dhis.android.sdk.R.string.detailed_info_dataelement),
+                eventClick.getRow().getDescription(), getResources().getString(
+                        org.hisp.dhis.android.sdk.R.string.ok_option),
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int i) {
+                        dialog.dismiss();
+                    }
+                });
     }
 }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -832,10 +832,10 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
             if (mForm.getProgram() != null && mForm.getProgram().getOnlyEnrollOnce()) {
                 if(lastEnrollment.getStatus().equals(Enrollment.CANCELLED)) {
                     newEnrollmentButton.setVisibility(View.VISIBLE);
-                    noActiveEnrollment.setText(R.string.enrollemnt_cancelled);
+                    noActiveEnrollment.setText(R.string.enrollment_cancelled);
                 }else{
                     newEnrollmentButton.setVisibility(View.GONE);
-                    noActiveEnrollment.setText(R.string.enrollemnt_complete);
+                    noActiveEnrollment.setText(R.string.enrollment_complete);
                 }
             }
         }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -1108,7 +1108,7 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
 
     private Enrollment getLastEnrollmentForTrackedEntityInstance() {
         List<Enrollment> enrollments = TrackerController.getEnrollments(
-                mForm.getTrackedEntityInstance());
+                mForm.getTrackedEntityInstance(), mForm.getProgram().getUid(), mForm.getTrackedEntityInstance().getOrgUnit());
          if(enrollments==null || enrollments.size()==0) {
             return null;
         }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -33,6 +33,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
 import android.support.v4.widget.SwipeRefreshLayout;
@@ -495,6 +496,11 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
 
             mSpinner.setSelection(getSpinnerIndex(mState.getProgramName()));
 
+            if(mForm!=null){
+                setRelationships(
+                        getLayoutInflater(getArguments().getBundle(EXTRA_SAVED_INSTANCE_STATE)));
+            }
+
             if (mForm == null || mForm.getEnrollment() == null) {
                 showNoActiveEnrollment(mForm);
                 return;
@@ -590,8 +596,6 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                     }
                 }
             }
-            setRelationships(
-                    getLayoutInflater(getArguments().getBundle(EXTRA_SAVED_INSTANCE_STATE)));
 
             LinearLayout programIndicatorLayout =
                     (LinearLayout) programIndicatorCardView.findViewById(
@@ -674,6 +678,17 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
 
                     relativeLabel.setText(relativeString);
 
+                    relativeLabel.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            if(!relationship.getTrackedEntityInstanceA().equals(mForm.getTrackedEntityInstance().getUid())) {
+                                moveToRelative(relationship.getTrackedEntityInstanceA(), getActivity());
+                            }
+                            else{
+                                moveToRelative(relationship.getTrackedEntityInstanceB(), getActivity());
+                            }
+                        }
+                    });
                     ll.setOnClickListener(new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
@@ -698,6 +713,12 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                 }
             }
         }
+    }
+
+    private void moveToRelative(String trackedEntityInstanceUid, FragmentActivity activity) {
+        activity.finish();
+        TrackedEntityInstance trackedEntityInstance =TrackerController.getTrackedEntityInstance(trackedEntityInstanceUid);
+        HolderActivity.navigateToProgramOverviewFragment(activity, mState.getOrgUnitId(), mState.getProgramId(), trackedEntityInstance.getLocalId());
     }
 
     private String getRelativeString(TrackedEntityInstance relative) {
@@ -826,18 +847,21 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                         trackedEntityInstance.getLocalId());
         {
             //update profile view
-            if (trackedEntityAttributeValues != null) {
+            if (trackedEntityAttributeValues != null && trackedEntityAttributeValues.size()>0) {
                 TrackedEntityAttribute attribute = MetaDataController.getTrackedEntityAttribute(
                         trackedEntityAttributeValues.get(0).getTrackedEntityAttributeId());
                 if (attribute != null) {
                     attribute1Label.setText(attribute.getName());
                     attribute1Value.setText(trackedEntityAttributeValues.get(0).getValue());
                 }
-                attribute = MetaDataController.getTrackedEntityAttribute(
-                        trackedEntityAttributeValues.get(1).getTrackedEntityAttributeId());
-                if (attribute != null) {
-                    attribute2Label.setText(attribute.getName());
-                    attribute2Value.setText(trackedEntityAttributeValues.get(1).getValue());
+
+                if (trackedEntityAttributeValues.size()>1) {
+                    attribute = MetaDataController.getTrackedEntityAttribute(
+                            trackedEntityAttributeValues.get(1).getTrackedEntityAttributeId());
+                    if (attribute != null) {
+                        attribute2Label.setText(attribute.getName());
+                        attribute2Value.setText(trackedEntityAttributeValues.get(1).getValue());
+                    }
                 }
             }
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -996,9 +996,9 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
 
             case R.id.complete: {
                 UiUtils.showConfirmDialog(getActivity(),
-                        getString(R.string.complete),
+                        getString(R.string.un_enroll),
                         getString(R.string.confirm_complete_enrollment),
-                        getString(R.string.complete),
+                        getString(R.string.un_enroll),
                         getString(R.string.cancel),
                         new DialogInterface.OnClickListener() {
                             @Override

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -573,9 +573,6 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
                             // to create exactly one event
                             stageRow.setButtonListener(this);
                         }
-                        if (stageRow.getProgramStage().getAllowGenerateNextVisit()) {
-                            stageRow.setButtonListener(this);
-                        }
                     }
 
                 } else if (row instanceof ProgramStageEventRow) {

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragment.java
@@ -826,12 +826,17 @@ public class ProgramOverviewFragment extends AbsProgramRuleFragment implements V
         noActiveEnrollment.setText(R.string.no_active_enrollment);
 
         missingEnrollmentLayout.setVisibility(View.VISIBLE);
-        List<Enrollment> enrollments = TrackerController.getEnrollments(mForm.getProgram().getUid(),
+        Enrollment lastEnrollment = TrackerController.getLastEnrollment(mForm.getProgram().getUid(),
                 mForm.getTrackedEntityInstance());
-        if(enrollments!=null && enrollments.size()>0) {
+        if(lastEnrollment!=null) {
             if (mForm.getProgram() != null && mForm.getProgram().getOnlyEnrollOnce()) {
-                newEnrollmentButton.setVisibility(View.GONE);
-                noActiveEnrollment.setText(R.string.enrollemnt_complete);
+                if(lastEnrollment.getStatus().equals(Enrollment.CANCELLED)) {
+                    newEnrollmentButton.setVisibility(View.VISIBLE);
+                    noActiveEnrollment.setText(R.string.enrollemnt_cancelled);
+                }else{
+                    newEnrollmentButton.setVisibility(View.GONE);
+                    noActiveEnrollment.setText(R.string.enrollemnt_complete);
+                }
             }
         }
         if(getLastEnrollmentForTrackedEntityInstance()==null){

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
@@ -121,13 +121,17 @@ class ProgramOverviewFragmentQuery implements Query<ProgramOverviewFragmentForm>
         programOverviewFragmentForm.setProgramIndicatorRows(new LinkedHashMap<ProgramIndicator, IndicatorRow>());
         if(programIndicators != null ) {
             for(ProgramIndicator programIndicator : programIndicators) {
-                String value = ProgramIndicatorService.getProgramIndicatorValue(programOverviewFragmentForm.getEnrollment(), programIndicator);
-                if(value!=null) {
-                    IndicatorRow indicatorRow = new IndicatorRow(programIndicator, value,
-                            programIndicator.getDisplayDescription());
-                    programOverviewFragmentForm.getProgramIndicatorRows().put(programIndicator,
-                            indicatorRow);
+                if(!programIndicator.isDisplayInForm()){
+                    continue;
                 }
+                String value = ProgramIndicatorService.getProgramIndicatorValue(programOverviewFragmentForm.getEnrollment(), programIndicator);
+                if(value==null) {
+                    continue;
+                }
+                IndicatorRow indicatorRow = new IndicatorRow(programIndicator, value,
+                        programIndicator.getDisplayDescription());
+                programOverviewFragmentForm.getProgramIndicatorRows().put(programIndicator,
+                        indicatorRow);
             }
         }else{
             programOverviewFragmentForm.getProgramIndicatorRows().clear();

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.android.trackercapture.ui.rows.programoverview.ProgramStage
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 class ProgramOverviewFragmentQuery implements Query<ProgramOverviewFragmentForm> {
@@ -117,13 +118,15 @@ class ProgramOverviewFragmentQuery implements Query<ProgramOverviewFragmentForm>
         programOverviewFragmentForm.setProgramStageRows(programStageRows);
 
         List<ProgramIndicator> programIndicators = programOverviewFragmentForm.getProgram().getProgramIndicators();
-        programOverviewFragmentForm.setProgramIndicatorRows(new HashMap<ProgramIndicator, IndicatorRow>());
+        programOverviewFragmentForm.setProgramIndicatorRows(new LinkedHashMap<ProgramIndicator, IndicatorRow>());
         if(programIndicators != null ) {
             for(ProgramIndicator programIndicator : programIndicators) {
                 String value = ProgramIndicatorService.getProgramIndicatorValue(programOverviewFragmentForm.getEnrollment(), programIndicator);
-                IndicatorRow indicatorRow = new IndicatorRow(programIndicator, value);
+                IndicatorRow indicatorRow = new IndicatorRow(programIndicator, value, programIndicator.getDisplayDescription());
                 programOverviewFragmentForm.getProgramIndicatorRows().put(programIndicator, indicatorRow);
             }
+        }else{
+            programOverviewFragmentForm.getProgramIndicatorRows().clear();
         }
         return programOverviewFragmentForm;
     }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/programoverview/ProgramOverviewFragmentQuery.java
@@ -122,8 +122,12 @@ class ProgramOverviewFragmentQuery implements Query<ProgramOverviewFragmentForm>
         if(programIndicators != null ) {
             for(ProgramIndicator programIndicator : programIndicators) {
                 String value = ProgramIndicatorService.getProgramIndicatorValue(programOverviewFragmentForm.getEnrollment(), programIndicator);
-                IndicatorRow indicatorRow = new IndicatorRow(programIndicator, value, programIndicator.getDisplayDescription());
-                programOverviewFragmentForm.getProgramIndicatorRows().put(programIndicator, indicatorRow);
+                if(value!=null) {
+                    IndicatorRow indicatorRow = new IndicatorRow(programIndicator, value,
+                            programIndicator.getDisplayDescription());
+                    programOverviewFragmentForm.getProgramIndicatorRows().put(programIndicator,
+                            indicatorRow);
+                }
             }
         }else{
             programOverviewFragmentForm.getProgramIndicatorRows().clear();

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragment.java
@@ -23,15 +23,11 @@ import com.squareup.otto.Subscribe;
 import org.hisp.dhis.android.sdk.controllers.GpsController;
 import org.hisp.dhis.android.sdk.persistence.Dhis2Application;
 import org.hisp.dhis.android.sdk.persistence.loaders.DbLoader;
-
-import org.hisp.dhis.android.sdk.persistence.models.Enrollment;
-import org.hisp.dhis.android.sdk.persistence.models.Event;
 import org.hisp.dhis.android.sdk.persistence.models.FailedItem;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
-import org.hisp.dhis.android.sdk.ui.activities.INavigationHandler;
 import org.hisp.dhis.android.sdk.ui.adapters.DataValueAdapter;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CoordinatesRow;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EventCoordinatesRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.IndicatorRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.StatusRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.events.OnDetailedInfoButtonClick;
@@ -43,7 +39,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class LocalSearchFragment extends Fragment implements LoaderManager.LoaderCallbacks<LocalSearchFragmentForm> {
+public class LocalSearchFragment extends Fragment implements
+        LoaderManager.LoaderCallbacks<LocalSearchFragmentForm> {
     public static final String EXTRA_PROGRAM = "extra:ProgramId";
     public static final String EXTRA_ORGUNIT = "extra:OrgUnitId";
     public static final String EXTRA_SAVED_INSTANCE_STATE = "extra:savedInstanceState";
@@ -70,11 +67,11 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-    Bundle arguments = getArguments();
-    programId = arguments.getString(EXTRA_PROGRAM);
-    orgUnitId = arguments.getString(EXTRA_ORGUNIT);
+        Bundle arguments = getArguments();
+        programId = arguments.getString(EXTRA_PROGRAM);
+        orgUnitId = arguments.getString(EXTRA_ORGUNIT);
 
-    setHasOptionsMenu(true);
+        setHasOptionsMenu(true);
 
     }
 
@@ -91,21 +88,28 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
     }
 
     @Subscribe
-    public void onShowDetailedInfo(OnDetailedInfoButtonClick eventClick) // may re-use code from DataEntryFragment
+    public void onShowDetailedInfo(
+            OnDetailedInfoButtonClick eventClick) // may re-use code from DataEntryFragment
     {
         String message = "";
 
-        if (eventClick.getRow() instanceof CoordinatesRow)
-            message = getResources().getString(org.hisp.dhis.android.sdk.R.string.detailed_info_coordinate_row);
-        else if (eventClick.getRow() instanceof StatusRow)
-            message = getResources().getString(org.hisp.dhis.android.sdk.R.string.detailed_info_status_row);
-        else if (eventClick.getRow() instanceof IndicatorRow)
+        if (eventClick.getRow() instanceof EventCoordinatesRow){
+            message = getResources().getString(
+                    org.hisp.dhis.android.sdk.R.string.detailed_info_coordinate_row);
+        } else if (eventClick.getRow() instanceof StatusRow) {
+            message = getResources().getString(
+                    org.hisp.dhis.android.sdk.R.string.detailed_info_status_row);
+        } else if (eventClick.getRow() instanceof IndicatorRow) {
             message = ""; // need to change ProgramIndicator to extend BaseValue for this to work
-        else         // rest of the rows can either be of data element or tracked entity instance attribute
+        } else         // rest of the rows can either be of data element or tracked entity instance
+        // attribute
+        {
             message = eventClick.getRow().getDescription();
+        }
 
         UiUtils.showConfirmDialog(getActivity(),
-                getResources().getString(org.hisp.dhis.android.sdk.R.string.detailed_info_dataelement),
+                getResources().getString(
+                        org.hisp.dhis.android.sdk.R.string.detailed_info_dataelement),
                 message, getResources().getString(org.hisp.dhis.android.sdk.R.string.ok_option),
                 new DialogInterface.OnClickListener() {
                     @Override
@@ -128,14 +132,14 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
 
             buildQuery();
 //            LocalSearchResultFragment fragment = LocalSearchResultFragment.newInstance(
-//                    mForm.getOrganisationUnitId(), mForm.getProgram(), mForm.getAttributeValues());
+//                    mForm.getOrganisationUnitId(), mForm.getProgram(), mForm.getAttributeValues
+// ());
             HolderActivity.navigateToLocalSearchResultFragment(getActivity(),
                     mForm.getOrganisationUnitId(),
                     mForm.getProgram(), mForm.getAttributeValues());
 //            navigationHandler.switchFragment(
 //                    fragment, fragment.getClass().getSimpleName(), true);
-        }
-        else if (id == android.R.id.home) {
+        } else if (id == android.R.id.home) {
             getActivity().finish();
             return true;
         }
@@ -156,8 +160,8 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
     public void buildQuery() {
         HashMap<String, String> attributeValueMap = new HashMap<>();
 
-        for(TrackedEntityAttributeValue value : mForm.getTrackedEntityAttributeValues()) {
-            if(value.getValue() != null && !value.getValue().isEmpty()) {
+        for (TrackedEntityAttributeValue value : mForm.getTrackedEntityAttributeValues()) {
+            if (value.getValue() != null && !value.getValue().isEmpty()) {
                 attributeValueMap.put(value.getTrackedEntityAttributeId(), value.getValue());
             }
         }
@@ -167,7 +171,8 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
 
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.activity_local_search, container, false);
     }
 
@@ -175,13 +180,15 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        if(getActivity() instanceof AppCompatActivity) {
+        if (getActivity() instanceof AppCompatActivity) {
             getActionBar().setTitle(getString(R.string.local_search));
             getActionBar().setDisplayHomeAsUpEnabled(true);
             getActionBar().setHomeButtonEnabled(true);
         }
-        trackedEntityAttributeListView = (ListView) view.findViewById(R.id.localSearchAttributeListView);
-        mAdapter = new DataValueAdapter(getChildFragmentManager(), getActivity().getLayoutInflater());
+        trackedEntityAttributeListView = (ListView) view.findViewById(
+                R.id.localSearchAttributeListView);
+        mAdapter = new DataValueAdapter(getChildFragmentManager(),
+                getActivity().getLayoutInflater());
         trackedEntityAttributeListView.setAdapter(mAdapter);
     }
 
@@ -228,7 +235,8 @@ public class LocalSearchFragment extends Fragment implements LoaderManager.Loade
     }
 
     @Override
-    public void onLoadFinished(Loader<LocalSearchFragmentForm> loader, LocalSearchFragmentForm data) {
+    public void onLoadFinished(Loader<LocalSearchFragmentForm> loader,
+            LocalSearchFragmentForm data) {
         if (loader.getId() == LOADER_ID && isAdded()) {
             trackedEntityAttributeListView.setVisibility(View.VISIBLE);
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragmentFormQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/LocalSearchFragmentFormQuery.java
@@ -6,18 +6,11 @@ import android.util.Log;
 import org.hisp.dhis.android.sdk.controllers.GpsController;
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowFactory;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.autocompleterow.AutoCompleteRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CheckBoxRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DatePickerRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RadioButtonsRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.utils.api.ValueType;
 
@@ -33,6 +26,7 @@ public class LocalSearchFragmentFormQuery implements Query<LocalSearchFragmentFo
         this.orgUnitId = orgUnitId;
         this.programId = programId;
     }
+
     @Override
     public LocalSearchFragmentForm query(Context context) {
         LocalSearchFragmentForm form = new LocalSearchFragmentForm();
@@ -42,33 +36,35 @@ public class LocalSearchFragmentFormQuery implements Query<LocalSearchFragmentFo
         Log.d(TAG, orgUnitId + programId);
 
         Program program = MetaDataController.getProgram(programId);
-        if(program == null || orgUnitId == null) {
+        if (program == null || orgUnitId == null) {
             return form;
         }
-        List<ProgramTrackedEntityAttribute> programAttrs = program.getProgramTrackedEntityAttributes();
+        List<ProgramTrackedEntityAttribute> programAttrs =
+                program.getProgramTrackedEntityAttributes();
         List<TrackedEntityAttributeValue> values = new ArrayList<>();
         List<Row> dataEntryRows = new ArrayList<>();
-        for(ProgramTrackedEntityAttribute ptea: programAttrs) {
+        for (ProgramTrackedEntityAttribute ptea : programAttrs) {
             TrackedEntityAttribute trackedEntityAttribute = ptea.getTrackedEntityAttribute();
             TrackedEntityAttributeValue value = new TrackedEntityAttributeValue();
             value.setTrackedEntityAttributeId(trackedEntityAttribute.getUid());
             values.add(value);
 
-            if(ptea.getMandatory()) {
-                ptea.setMandatory(!ptea.getMandatory()); // HACK to skip mandatory fields in search form
+            if (ptea.getMandatory()) {
+                ptea.setMandatory(
+                        !ptea.getMandatory()); // HACK to skip mandatory fields in search form
             }
-            if(ValueType.COORDINATE.equals(ptea.getTrackedEntityAttribute().getValueType())) {
+            if (ValueType.COORDINATE.equals(ptea.getTrackedEntityAttribute().getValueType())) {
                 GpsController.activateGps(context);
             }
             Row row = DataEntryRowFactory.createDataEntryView(ptea.getMandatory(),
                     ptea.getAllowFutureDate(), trackedEntityAttribute.getOptionSet(),
-                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false,program.getDataEntryMethod());
+                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(),
+                    true, false, program.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         form.setTrackedEntityAttributeValues(values);
         form.setDataEntryRows(dataEntryRows);
         return form;
-
 
 
     }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragment.java
@@ -35,7 +35,7 @@ import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.adapters.DataValueAdapter;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.AbsTextWatcher;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CoordinatesRow;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EventCoordinatesRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.IndicatorRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.StatusRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.events.OnDetailedInfoButtonClick;
@@ -238,7 +238,7 @@ public class OnlineSearchFragment extends Fragment implements View.OnClickListen
     {
         String message = "";
 
-        if (eventClick.getRow() instanceof CoordinatesRow)
+        if (eventClick.getRow() instanceof EventCoordinatesRow)
             message = getResources().getString(org.hisp.dhis.android.sdk.R.string.detailed_info_coordinate_row);
         else if (eventClick.getRow() instanceof StatusRow)
             message = getResources().getString(org.hisp.dhis.android.sdk.R.string.detailed_info_status_row);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragmentQuery.java
@@ -5,20 +5,12 @@ import android.util.Log;
 
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowFactory;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.autocompleterow.AutoCompleteRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CheckBoxRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DatePickerRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RadioButtonsRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
-import org.hisp.dhis.android.sdk.utils.api.ValueType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,15 +21,13 @@ public class OnlineSearchFragmentQuery implements Query<OnlineSearchFragmentForm
     private String orgUnit;
     private String programId;
 
-    public OnlineSearchFragmentQuery(String orgUnit, String programId)
-    {
+    public OnlineSearchFragmentQuery(String orgUnit, String programId) {
         this.programId = programId;
         this.orgUnit = orgUnit;
     }
 
     @Override
-    public OnlineSearchFragmentForm query(Context context)
-    {
+    public OnlineSearchFragmentForm query(Context context) {
         OnlineSearchFragmentForm form = new OnlineSearchFragmentForm();
         form.setOrganisationUnit(orgUnit);
         form.setProgram(programId);
@@ -45,25 +35,28 @@ public class OnlineSearchFragmentQuery implements Query<OnlineSearchFragmentForm
         Log.d(TAG, orgUnit + programId);
 
         Program program = MetaDataController.getProgram(programId);
-        if(program == null || orgUnit == null) {
+        if (program == null || orgUnit == null) {
             return form;
         }
-        List<ProgramTrackedEntityAttribute> programAttrs = program.getProgramTrackedEntityAttributes();
+        List<ProgramTrackedEntityAttribute> programAttrs =
+                program.getProgramTrackedEntityAttributes();
         List<TrackedEntityAttributeValue> values = new ArrayList<>();
         List<Row> dataEntryRows = new ArrayList<>();
-        for(ProgramTrackedEntityAttribute ptea: programAttrs) {
+        for (ProgramTrackedEntityAttribute ptea : programAttrs) {
             TrackedEntityAttribute trackedEntityAttribute = ptea.getTrackedEntityAttribute();
             TrackedEntityAttributeValue value = new TrackedEntityAttributeValue();
             value.setTrackedEntityAttributeId(trackedEntityAttribute.getUid());
             values.add(value);
 
-            if(ptea.getMandatory()) {
-                ptea.setMandatory(!ptea.getMandatory()); // HACK to skip mandatory fields in search form
+            if (ptea.getMandatory()) {
+                ptea.setMandatory(
+                        !ptea.getMandatory()); // HACK to skip mandatory fields in search form
             }
 
             Row row = DataEntryRowFactory.createDataEntryView(ptea.getMandatory(),
                     ptea.getAllowFutureDate(), trackedEntityAttribute.getOptionSet(),
-                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false, program.getDataEntryMethod());
+                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(),
+                    true, false, program.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         form.setTrackedEntityAttributeValues(values);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchFragmentQuery.java
@@ -5,20 +5,12 @@ import android.util.Log;
 
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowFactory;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.autocompleterow.AutoCompleteRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CheckBoxRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DatePickerRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RadioButtonsRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
-import org.hisp.dhis.android.sdk.utils.api.ValueType;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/search/OnlineSearchResultFragment.java
@@ -185,7 +185,9 @@ public class OnlineSearchResultFragment extends Fragment implements AdapterView.
         } else {
         }
 
-        mAdapter = new QueryTrackedEntityInstancesResultDialogAdapter(LayoutInflater.from(getActivity()), getSelectedTrackedEntityInstances(), programTrackedEntityAttributeMap);
+        mAdapter = new QueryTrackedEntityInstancesResultDialogAdapter(
+                LayoutInflater.from(getActivity()), getSelectedTrackedEntityInstances(),
+                programTrackedEntityAttributeMap, getContext());
         mListView.setAdapter(mAdapter);
         mListView.setOnItemClickListener(this);
 

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/dialogs/QueryTrackedEntityInstancesDialogFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/dialogs/QueryTrackedEntityInstancesDialogFragment.java
@@ -36,7 +36,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.app.DialogFragment;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.LoaderManager;
@@ -70,7 +69,7 @@ import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.adapters.DataValueAdapter;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.AbsTextWatcher;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CoordinatesRow;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EventCoordinatesRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.IndicatorRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.StatusRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.events.OnDetailedInfoButtonClick;
@@ -78,7 +77,6 @@ import org.hisp.dhis.android.sdk.ui.dialogs.QueryTrackedEntityInstancesResultDia
 import org.hisp.dhis.android.sdk.ui.views.FloatingActionButton;
 import org.hisp.dhis.android.sdk.utils.UiUtils;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -251,7 +249,7 @@ public class QueryTrackedEntityInstancesDialogFragment extends DialogFragment
     {
         String message = "";
 
-        if (eventClick.getRow() instanceof CoordinatesRow)
+        if (eventClick.getRow() instanceof EventCoordinatesRow)
             message = getResources().getString(R.string.detailed_info_coordinate_row);
         else if (eventClick.getRow() instanceof StatusRow)
             message = getResources().getString(R.string.detailed_info_status_row);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/dialogs/QueryTrackedEntityInstancesDialogFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/selectprogram/dialogs/QueryTrackedEntityInstancesDialogFragmentQuery.java
@@ -35,18 +35,11 @@ import android.util.Log;
 import org.hisp.dhis.android.sdk.controllers.GpsController;
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowFactory;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.autocompleterow.AutoCompleteRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CheckBoxRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DatePickerRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RadioButtonsRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.utils.api.ValueType;
 
@@ -56,45 +49,47 @@ import java.util.List;
 /**
  * Created by Simen S. Russnes on 7/9/15.
  */
-public class QueryTrackedEntityInstancesDialogFragmentQuery implements Query<QueryTrackedEntityInstancesDialogFragmentForm>
-{
-    public static final String TAG = QueryTrackedEntityInstancesDialogFragmentQuery.class.getSimpleName();
+public class QueryTrackedEntityInstancesDialogFragmentQuery implements
+        Query<QueryTrackedEntityInstancesDialogFragmentForm> {
+    public static final String TAG =
+            QueryTrackedEntityInstancesDialogFragmentQuery.class.getSimpleName();
     private String orgUnit;
     private String programId;
 
-    public QueryTrackedEntityInstancesDialogFragmentQuery(String orgUnit, String programId)
-    {
+    public QueryTrackedEntityInstancesDialogFragmentQuery(String orgUnit, String programId) {
         this.programId = programId;
         this.orgUnit = orgUnit;
     }
 
     @Override
-    public QueryTrackedEntityInstancesDialogFragmentForm query(Context context)
-    {
-        QueryTrackedEntityInstancesDialogFragmentForm form = new QueryTrackedEntityInstancesDialogFragmentForm();
+    public QueryTrackedEntityInstancesDialogFragmentForm query(Context context) {
+        QueryTrackedEntityInstancesDialogFragmentForm form =
+                new QueryTrackedEntityInstancesDialogFragmentForm();
         form.setOrganisationUnit(orgUnit);
         form.setProgram(programId);
 
         Log.d(TAG, orgUnit + programId);
 
         Program program = MetaDataController.getProgram(programId);
-        if(program == null || orgUnit == null) {
+        if (program == null || orgUnit == null) {
             return form;
         }
-        List<ProgramTrackedEntityAttribute> programAttrs = program.getProgramTrackedEntityAttributes();
+        List<ProgramTrackedEntityAttribute> programAttrs =
+                program.getProgramTrackedEntityAttributes();
         List<TrackedEntityAttributeValue> values = new ArrayList<>();
         List<Row> dataEntryRows = new ArrayList<>();
-        for(ProgramTrackedEntityAttribute ptea: programAttrs) {
+        for (ProgramTrackedEntityAttribute ptea : programAttrs) {
             TrackedEntityAttribute trackedEntityAttribute = ptea.getTrackedEntityAttribute();
             TrackedEntityAttributeValue value = new TrackedEntityAttributeValue();
             value.setTrackedEntityAttributeId(trackedEntityAttribute.getUid());
             values.add(value);
-            if(ValueType.COORDINATE.equals(ptea.getTrackedEntityAttribute().getValueType())) {
+            if (ValueType.COORDINATE.equals(ptea.getTrackedEntityAttribute().getValueType())) {
                 GpsController.activateGps(context);
             }
             Row row = DataEntryRowFactory.createDataEntryView(ptea.getMandatory(),
                     ptea.getAllowFutureDate(), trackedEntityAttribute.getOptionSet(),
-                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(), true, false, program.getDataEntryMethod());
+                    trackedEntityAttribute.getName(), value, trackedEntityAttribute.getValueType(),
+                    true, false, program.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         form.setTrackedEntityAttributeValues(values);

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragment.java
@@ -29,6 +29,8 @@
 
 package org.hisp.dhis.android.trackercapture.fragments.trackedentityinstanceprofile;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.content.Loader;
@@ -51,7 +53,6 @@ import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.activities.OnBackPressedListener;
 import org.hisp.dhis.android.sdk.ui.adapters.SectionAdapter;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RunProgramRulesEvent;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.events.OnDetailedInfoButtonClick;
@@ -67,8 +68,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Created by erling on 5/18/15.
@@ -306,7 +305,7 @@ public class TrackedEntityInstanceProfileFragment extends DataEntryFragment<Trac
             return;
         }
         // do not run program rules for EditTextRows - DelayedDispatcher takes care of this
-        if (event.getRow() == null || !(event.getRow() instanceof EditTextRow)) {
+        if (event.getRow() == null || !(event.getRow().isEditTextRow())) {
             evaluateRules(event.getId());
         }
         saveThread.schedule();

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragment.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragment.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.activities.OnBackPressedListener;
 import org.hisp.dhis.android.sdk.ui.adapters.SectionAdapter;
+import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RunProgramRulesEvent;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.events.OnDetailedInfoButtonClick;
@@ -459,10 +460,15 @@ public class TrackedEntityInstanceProfileFragment extends DataEntryFragment<Trac
     private boolean validate() {
         ArrayList<String> programRulesValidationErrors = getProgramRuleFragmentHelper().getProgramRuleValidationErrors();
         ArrayList<String> mandatoryValidationErrors = getValidationErrors();
-        if (programRulesValidationErrors.isEmpty() && mandatoryValidationErrors.isEmpty()) {
+        ArrayList<String> validationErrors = new ArrayList<>();
+        for(DataEntryRow dataEntryRow : form.getDataEntryRows()){
+            if(dataEntryRow.getValidationError()!=null)
+                validationErrors.add(getContext().getString(dataEntryRow.getValidationError()));
+        }
+        if (programRulesValidationErrors.isEmpty() && mandatoryValidationErrors.isEmpty() && validationErrors.isEmpty()) {
             return true;
         } else {
-            showValidationErrorDialog(mandatoryValidationErrors, programRulesValidationErrors);
+            showValidationErrorDialog(mandatoryValidationErrors, programRulesValidationErrors, validationErrors);
             return false;
         }
     }

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/trackedentityinstanceprofile/TrackedEntityInstanceProfileFragmentQuery.java
@@ -36,19 +36,11 @@ import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
 import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
 import org.hisp.dhis.android.sdk.persistence.models.Enrollment;
-import org.hisp.dhis.android.sdk.persistence.models.OptionSet;
 import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramTrackedEntityAttribute;
-import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityInstance;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowFactory;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.autocompleterow.AutoCompleteRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.CheckBoxRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DataEntryRowTypes;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.DatePickerRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.EditTextRow;
-import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.RadioButtonsRow;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.dataentry.Row;
 import org.hisp.dhis.android.sdk.utils.api.ValueType;
 
@@ -59,7 +51,8 @@ import java.util.List;
 /**
  * Created by erling on 5/19/15.
  */
-public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedEntityInstanceProfileFragmentForm> {
+public class TrackedEntityInstanceProfileFragmentQuery implements
+        Query<TrackedEntityInstanceProfileFragmentForm> {
     private long mTrackedEntityInstanceId;
     private String mProgramId;
     private TrackedEntityInstance currentTrackedEntityInstance;
@@ -67,7 +60,8 @@ public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedE
     private long enrollmentId;
     private Enrollment currentEnrollment;
 
-    public TrackedEntityInstanceProfileFragmentQuery(long mTrackedEntityInstanceId, String mProgramId, long enrollmentId) {
+    public TrackedEntityInstanceProfileFragmentQuery(long mTrackedEntityInstanceId,
+            String mProgramId, long enrollmentId) {
         this.mTrackedEntityInstanceId = mTrackedEntityInstanceId;
         this.mProgramId = mProgramId;
         this.enrollmentId = enrollmentId;
@@ -75,9 +69,11 @@ public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedE
 
     @Override
     public TrackedEntityInstanceProfileFragmentForm query(Context context) {
-        TrackedEntityInstanceProfileFragmentForm mForm = new TrackedEntityInstanceProfileFragmentForm();
+        TrackedEntityInstanceProfileFragmentForm mForm =
+                new TrackedEntityInstanceProfileFragmentForm();
         final Program mProgram = MetaDataController.getProgram(mProgramId);
-        final TrackedEntityInstance mTrackedEntityInstance = TrackerController.getTrackedEntityInstance(mTrackedEntityInstanceId);
+        final TrackedEntityInstance mTrackedEntityInstance =
+                TrackerController.getTrackedEntityInstance(mTrackedEntityInstanceId);
 
         if (mProgram == null || mTrackedEntityInstance == null) {
             return mForm;
@@ -88,8 +84,11 @@ public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedE
         mForm.setTrackedEntityInstance(mTrackedEntityInstance);
         mForm.setTrackedEntityAttributeValueMap(new HashMap<String, TrackedEntityAttributeValue>());
 
-        List<TrackedEntityAttributeValue> trackedEntityAttributeValues = TrackerController.getProgramTrackedEntityAttributeValues(mProgram, mTrackedEntityInstance);
-        List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes = MetaDataController.getProgramTrackedEntityAttributes(mProgramId);
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues =
+                TrackerController.getProgramTrackedEntityAttributeValues(mProgram,
+                        mTrackedEntityInstance);
+        List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes =
+                MetaDataController.getProgramTrackedEntityAttributes(mProgramId);
 
         if (trackedEntityAttributeValues == null && programTrackedEntityAttributes == null) {
             return mForm;
@@ -99,21 +98,32 @@ public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedE
         List<Row> dataEntryRows = new ArrayList<>();
         for (int i = 0; i < programTrackedEntityAttributes.size(); i++) {
             boolean shouldNeverBeEdited = false;
-            if(programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().isGenerated()) {
+            if (programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().isGenerated()) {
                 shouldNeverBeEdited = true;
             }
-            if(ValueType.COORDINATE.equals(programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getValueType())) {
+            if (ValueType.COORDINATE.equals(programTrackedEntityAttributes.get(
+                    i).getTrackedEntityAttribute().getValueType())) {
                 GpsController.activateGps(context);
             }
-            Row row = DataEntryRowFactory.createDataEntryView(programTrackedEntityAttributes.get(i).getMandatory(),
-                    programTrackedEntityAttributes.get(i).getAllowFutureDate(), programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getOptionSet(),
-                    programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getName(), getTrackedEntityDataValue(programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getUid(),
-                            trackedEntityAttributeValues), programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getValueType(), false, shouldNeverBeEdited, mProgram.getDataEntryMethod());
+            Row row = DataEntryRowFactory.createDataEntryView(
+                    programTrackedEntityAttributes.get(i).getMandatory(),
+                    programTrackedEntityAttributes.get(i).getAllowFutureDate(),
+                    programTrackedEntityAttributes.get(
+                            i).getTrackedEntityAttribute().getOptionSet(),
+                    programTrackedEntityAttributes.get(i).getTrackedEntityAttribute().getName(),
+                    getTrackedEntityDataValue(programTrackedEntityAttributes.get(
+                            i).getTrackedEntityAttribute().getUid(),
+                            trackedEntityAttributeValues), programTrackedEntityAttributes.get(
+                            i).getTrackedEntityAttribute().getValueType(), false,
+                    shouldNeverBeEdited, mProgram.getDataEntryMethod());
             dataEntryRows.add(row);
         }
         if (trackedEntityAttributeValues != null) {
-            for (TrackedEntityAttributeValue trackedEntityAttributeValue : trackedEntityAttributeValues) {
-                mForm.getTrackedEntityAttributeValueMap().put(trackedEntityAttributeValue.getTrackedEntityAttributeId(), trackedEntityAttributeValue);
+            for (TrackedEntityAttributeValue trackedEntityAttributeValue :
+                    trackedEntityAttributeValues) {
+                mForm.getTrackedEntityAttributeValueMap().put(
+                        trackedEntityAttributeValue.getTrackedEntityAttributeId(),
+                        trackedEntityAttributeValue);
             }
         }
         mForm.setDataEntryRows(dataEntryRows);
@@ -121,9 +131,12 @@ public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedE
         return mForm;
     }
 
-    public TrackedEntityAttributeValue getTrackedEntityDataValue(String trackedEntityAttribute, List<TrackedEntityAttributeValue> trackedEntityAttributeValues) {
-        for (TrackedEntityAttributeValue trackedEntityAttributeValue : trackedEntityAttributeValues) {
-            if (trackedEntityAttributeValue.getTrackedEntityAttributeId().equals(trackedEntityAttribute)) {
+    public TrackedEntityAttributeValue getTrackedEntityDataValue(String trackedEntityAttribute,
+            List<TrackedEntityAttributeValue> trackedEntityAttributeValues) {
+        for (TrackedEntityAttributeValue trackedEntityAttributeValue :
+                trackedEntityAttributeValues) {
+            if (trackedEntityAttributeValue.getTrackedEntityAttributeId().equals(
+                    trackedEntityAttribute)) {
                 return trackedEntityAttributeValue;
             }
         }
@@ -131,8 +144,10 @@ public class TrackedEntityInstanceProfileFragmentQuery implements Query<TrackedE
         //the datavalue didnt exist for some reason. Create a new one.
         TrackedEntityAttributeValue trackedEntityAttributeValue = new TrackedEntityAttributeValue();
         trackedEntityAttributeValue.setTrackedEntityAttributeId(trackedEntityAttribute);
-        trackedEntityAttributeValue.setTrackedEntityInstanceId(currentTrackedEntityInstance.getTrackedEntityInstance());
-        trackedEntityAttributeValue.setLocalTrackedEntityInstanceId(currentTrackedEntityInstance.getLocalId());
+        trackedEntityAttributeValue.setTrackedEntityInstanceId(
+                currentTrackedEntityInstance.getTrackedEntityInstance());
+        trackedEntityAttributeValue.setLocalTrackedEntityInstanceId(
+                currentTrackedEntityInstance.getLocalId());
         trackedEntityAttributeValue.setValue("");
         trackedEntityAttributeValues.add(trackedEntityAttributeValue);
         return trackedEntityAttributeValue;

--- a/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/upcomingevents/UpcomingEventsFragmentQuery.java
+++ b/app/src/main/java/org/hisp/dhis/android/trackercapture/fragments/upcomingevents/UpcomingEventsFragmentQuery.java
@@ -33,11 +33,8 @@ import android.content.Context;
 
 import com.raizlabs.android.dbflow.sql.language.Select;
 
-import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.controllers.metadata.MetaDataController;
-import org.hisp.dhis.android.sdk.persistence.preferences.DateTimeManager;
-import org.hisp.dhis.android.sdk.ui.dialogs.UpcomingEventsDialogFilter;
-import org.hisp.dhis.android.sdk.ui.fragments.selectprogram.SelectProgramFragmentForm;
+import org.hisp.dhis.android.sdk.controllers.tracker.TrackerController;
 import org.hisp.dhis.android.sdk.persistence.loaders.Query;
 import org.hisp.dhis.android.sdk.persistence.models.Event;
 import org.hisp.dhis.android.sdk.persistence.models.Option;
@@ -45,9 +42,11 @@ import org.hisp.dhis.android.sdk.persistence.models.Program;
 import org.hisp.dhis.android.sdk.persistence.models.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.android.sdk.persistence.models.TrackedEntityAttributeValue;
 import org.hisp.dhis.android.sdk.ui.adapters.rows.events.EventRow;
+import org.hisp.dhis.android.sdk.ui.dialogs.UpcomingEventsDialogFilter;
+import org.hisp.dhis.android.sdk.ui.fragments.selectprogram.SelectProgramFragmentForm;
+import org.hisp.dhis.android.trackercapture.R;
 import org.hisp.dhis.android.trackercapture.ui.rows.upcomingevents.UpcomingEventItemRow;
 import org.hisp.dhis.android.trackercapture.ui.rows.upcomingevents.UpcomingEventsColumnNamesRow;
-import org.joda.time.DateTime;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -89,9 +88,9 @@ class UpcomingEventsFragmentQuery implements Query<SelectProgramFragmentForm> {
 
         List<String> attributesToShow = new ArrayList<>();
         UpcomingEventsColumnNamesRow columnNames = new UpcomingEventsColumnNamesRow();
-        String title = "EVENTS";
+        String title = context.getString(R.string.events);
         if(mFilterLabel!=null){
-            title = mFilterLabel + " " + title;
+            title = getLabelTitle(mFilterLabel, context);
         }
         columnNames.setTitle(title);
         for (ProgramTrackedEntityAttribute attribute : programTrackedEntityAttributes) {
@@ -139,6 +138,19 @@ class UpcomingEventsFragmentQuery implements Query<SelectProgramFragmentForm> {
         fragmentForm.setEventRowList(eventUpcomingEventRows);
         fragmentForm.setProgram(selectedProgram);
         return fragmentForm;
+    }
+
+    private String getLabelTitle(String filterLabel, Context context) {
+        if (UpcomingEventsDialogFilter.Type.UPCOMING.toString().equalsIgnoreCase(mFilterLabel)) {
+            return context.getString(R.string.upcoming_events);
+        } else if (UpcomingEventsDialogFilter.Type.OVERDUE.toString().equalsIgnoreCase(
+                mFilterLabel)) {
+            return context.getString(R.string.overdue_events);
+        } else if (UpcomingEventsDialogFilter.Type.ACTIVE.toString().equalsIgnoreCase(
+                mFilterLabel)) {
+            return context.getString(R.string.active_events);
+        }
+        return "";
     }
 
     private UpcomingEventItemRow createEventItem(Event event, List<String> attributesToShow,

--- a/app/src/main/res/layout/fragment_programoverview_header.xml
+++ b/app/src/main/res/layout/fragment_programoverview_header.xml
@@ -178,7 +178,7 @@
                     android:layout_margin="5dp"
                     android:layout_weight="1"
                     android:background="@drawable/rounded_imagebutton_orange"
-                    android:text="@string/complete" />
+                    android:text="@string/un_enroll" />
 
                 <Button
                     android:id="@+id/terminate"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -80,4 +80,8 @@
     <string name="enrollemnt_complete">Registro completo</string>
 
     <string name="profile_form_empty">El formulario está vacío, por favor rellene al menos un campo</string>
+    <string name="events">EVENTOS</string>
+    <string name="upcoming_events">PRÓXIMOS EVENTOS</string>
+    <string name="overdue_events">EVENTOS ATRASADOS</string>
+    <string name="active_events">EVENTOS ACTIVOS</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,4 +79,5 @@
     <string name="download_entities_title">Descargar entidades</string>
     <string name="enrollemnt_complete">Registro completo</string>
 
+    <string name="profile_form_empty">El formulario está vacío, por favor rellene al menos un campo</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -77,11 +77,12 @@
     <string name="re_open">Reabrir</string>
 
     <string name="download_entities_title">Descargar entidades</string>
-    <string name="enrollemnt_complete">Registro completo</string>
+    <string name="enrollment_complete">Registro completo</string>
 
     <string name="profile_form_empty">El formulario está vacío, por favor rellene al menos un campo</string>
     <string name="events">EVENTOS</string>
     <string name="upcoming_events">PRÓXIMOS EVENTOS</string>
     <string name="overdue_events">EVENTOS ATRASADOS</string>
     <string name="active_events">EVENTOS ACTIVOS</string>
+    <string name="enrollment_cancelled">Registro cancelado</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,7 +51,7 @@
     <string name="error_series_500_description">Error de servidor 50x. Por favor, intenta sincronizar más tarde.</string>
     <string name="unknown_error">Error desconocido</string>
 
-    <string name="confirm_complete_enrollment">¿Estás seguro de querer completar el registro\n        actual? No se podrá editar posteriormente</string>
+    <string name="confirm_complete_enrollment">¿Estás seguro de querer desinscribirse del registro\n        actual? No se podrá editar posteriormente</string>
     <string name="confirm_terminate_enrollment">¿Estás seguro de querer cancelar el registro\n        actual? No se podrá deshacer esta acción.</string>
     <string name="confirm_delete_relationship">¿Estás seguro de querer borrar esta relación?</string>
     <string name="no_active_enrollment">No existe registro activo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -77,10 +77,11 @@
     <string name="re_open">Rouvrir</string>
 
     <string name="download_entities_title">Télécharger entités</string>
-    <string name="enrollemnt_complete">Enregistrement complété</string>
+    <string name="enrollment_complete">Enregistrement complété</string>
     <string name="profile_form_empty">Le formulaire est vide, veuillez remplir au moins un</string>
     <string name="events">ÉVÉNEMENTS</string>
     <string name="upcoming_events">PROCHAINS ÉVÉNEMENTS</string>
     <string name="overdue_events">ÉVÉNEMENTS EN RETARD</string>
     <string name="active_events">ÉVÉNEMENTS ACTIFS</string>
+    <string name="enrollment_cancelled">Enregistrement annulé</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,7 +51,7 @@
     <string name="error_series_500_description">Erreur de serveur 50x. Prière de synchroniser plus tard.</string>
     <string name="unknown_error">Erreur inconnue</string>
 
-    <string name="confirm_complete_enrollment">Souhaitez-vous vraiment compléter l\'enregistrement?\n        Vous ne pourrez plus éditer ultérierement</string>
+    <string name="confirm_complete_enrollment">Souhaitez-vous vraiment désinscription l\'enregistrement?\n        Vous ne pourrez plus éditer ultérierement</string>
     <string name="confirm_terminate_enrollment">Souhaitez-vous vraiment annuler cette\n        enregistrement ? Vous ne pourrez plus revenir en arrière.</string>
     <string name="confirm_delete_relationship">Souhaitez-vous vraiment supprimer cette relation ?</string>
     <string name="no_active_enrollment">Pas d\'enregistrement actif</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -78,5 +78,5 @@
 
     <string name="download_entities_title">Télécharger entités</string>
     <string name="enrollemnt_complete">Enregistrement complété</string>
-
+    <string name="profile_form_empty">Le formulaire est vide, veuillez remplir au moins un</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -79,4 +79,8 @@
     <string name="download_entities_title">Télécharger entités</string>
     <string name="enrollemnt_complete">Enregistrement complété</string>
     <string name="profile_form_empty">Le formulaire est vide, veuillez remplir au moins un</string>
+    <string name="events">ÉVÉNEMENTS</string>
+    <string name="upcoming_events">PROCHAINS ÉVÉNEMENTS</string>
+    <string name="overdue_events">ÉVÉNEMENTS EN SOUFFRANCE</string>
+    <string name="active_events">ÉVÉNEMENTS ACTIFS</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -81,6 +81,6 @@
     <string name="profile_form_empty">Le formulaire est vide, veuillez remplir au moins un</string>
     <string name="events">ÉVÉNEMENTS</string>
     <string name="upcoming_events">PROCHAINS ÉVÉNEMENTS</string>
-    <string name="overdue_events">ÉVÉNEMENTS EN SOUFFRANCE</string>
+    <string name="overdue_events">ÉVÉNEMENTS EN RETARD</string>
     <string name="active_events">ÉVÉNEMENTS ACTIFS</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,5 @@
     <string name="download_entities_title">Download entities</string>
     <string name="enrollemnt_complete">Enrollment is complete</string>
 
+    <string name="profile_form_empty">Form is empty, please fill at least one</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,8 +79,8 @@
     <string name="re_open">Re-open</string>
 
     <string name="download_entities_title">Download entities</string>
-    <string name="enrollemnt_complete">Enrollment is complete</string>
-    <string name="enrollemnt_cancelled">Enrollment is cancelled</string>
+    <string name="enrollment_complete">Enrollment is complete</string>
+    <string name="enrollment_cancelled">Enrollment is cancelled</string>
 
     <string name="profile_form_empty">Form is empty, please fill at least one</string>
     <string name="events">EVENTS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="error_series_500_description">50x server error. Please, try to synchronize later.</string>
     <string name="unknown_error">Unknown error</string>
 
-    <string name="confirm_complete_enrollment">Are you sure you want to complete the current
+    <string name="confirm_complete_enrollment">Are you sure you want to un-enroll the current
         enrollment? No more editing will be possible.</string>
     <string name="confirm_terminate_enrollment">Are you sure you want to cancel the current
         enrollment? This cannot be undone.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
 
     <string name="download_entities_title">Download entities</string>
     <string name="enrollemnt_complete">Enrollment is complete</string>
+    <string name="enrollemnt_cancelled">Enrollment is cancelled</string>
 
     <string name="profile_form_empty">Form is empty, please fill at least one</string>
     <string name="events">EVENTS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,8 @@
     <string name="enrollemnt_complete">Enrollment is complete</string>
 
     <string name="profile_form_empty">Form is empty, please fill at least one</string>
+    <string name="events">EVENTS</string>
+    <string name="upcoming_events">UPCOMING EVENTS</string>
+    <string name="overdue_events">OVERDUE EVENTS</string>
+    <string name="active_events">ACTIVE EVENTS</string>
 </resources>

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Upload CodeCov report
+echo "ConnectedCheck: "
+./gradlew connectedCheck
+
+echo "Send report to CodeCov"
+bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Definitions
 gitPath=$(git rev-parse --show-toplevel)
@@ -11,3 +11,6 @@ sh ${gitPath}/generate_last_commit.sh
 cd sdk
 git checkout tracker-capture
 cd -
+
+echo "Generate Test Coverage Report:"
+./gradlew build jacocoTestReport assembleAndroidTest

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         classpath 'com.raizlabs:Griddle:1.0.3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ ext {
     minSdkVersion = 15
     compileSdkVersion = 23
     targetSdkVersion = 23
-    versionCode = 55
-    versionName = "0.3.38"
+    versionCode = 56
+    versionName = "0.3.39"
 
     configuration = [
             package          : "org.hisp.dhis.android.trackercapture",
@@ -41,8 +41,8 @@ ext {
             minSdkVersion    : 15,
             compileSdkVersion: 23,
             targetSdkVersion : 23,
-            versionCode      : 55,
-            versionName      : "0.3.38"
+            versionCode      : 56,
+            versionName      : "0.3.39"
     ]
 
     libraries = [


### PR DESCRIPTION
This PR contains the solution to the following issues:
New features:
- In coordinate field is disabled manual entry ( Android Tracker Capture App) (https://jira.dhis2.org/browse/ACA-87)
- Attributes and data elements of phone and email value type not supported by this app (https://jira.dhis2.org/browse/ACA-79)
- Create a link from name in relations to the TEI (https://jira.dhis2.org/browse/ACA-74)
- Change complete-incomplete text from enrollment button to avoid confusion with events completion (https://jira.dhis2.org/browse/ACA-38)
- Show a pop-up when exiting an event with invalid fields
- Add 2.27 servers compatibility
- Implement indicators

Bugfixing:
- TEI Attributes Displaying Incorrectly On Download Entities Screen (https://jira.dhis2.org/browse/ACA-100)
- When editing dates, date picker reverts to today's date, rather than edited date (https://jira.dhis2.org/browse/ACA-98)
- Non-repeatable program stage not being enforced (user can add two non-repeatable events) (https://jira.dhis2.org/browse/ACA-96)
- Event color coding (https://jira.dhis2.org/browse/ACA-93)
- Option sets not syncing with Android until local data is cleared (https://jira.dhis2.org/browse/ACA-92)
- Enrollment and Incident date labels dont display when Registering a tracked entity (https://jira.dhis2.org/browse/ACA-81)
- Delete invalid events (without OU) after pull
- Delete the enrollment on enrollment cancel (mark as cancelled locally and ignore it on re-open)
- DB was not being remove between different installations of the app
- Indicators layout
- Fix event dates layout
- Fix sync of complete actions on enrollment to the server
- Translations issues
- Sync relationships
- Fix InputFilter code in EditTextRows
- Fix indicators layout